### PR TITLE
Fixes loop that removes handlers to avoid IndexError

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -52,8 +52,8 @@ class TestMainWindow(unittest.TestCase):
         cls.window.undo_stack.setClean()
         cls.window.close()
         root_logger = config.logging.getLogger()
-        for i in range(1, len(root_logger.handlers)):
-            handler = root_logger.handlers[i]
+        for _ in range(len(root_logger.handlers) - 1):
+            handler = root_logger.handlers[-1]
             handler.close()
             root_logger.removeHandler(handler)
         config.logging.shutdown()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This fixes the tearDownClass method in TestMainWindow.


* **What is the current behavior?** (You can also link to an open issue here)

When running pytest:

```
cls = <class 'tests.test_ui.TestMainWindow'>

    @classmethod
    def tearDownClass(cls):
        cls.window.undo_stack.setClean()
        cls.window.close()
        root_logger = config.logging.getLogger()
        for i in range(1, len(root_logger.handlers)):
>           handler = root_logger.handlers[i]
E           IndexError: list index out of range

tests/test_ui.py:56: IndexError
```
Once some of the handlers have been removed, `i` can exceed the length of the array causing an IndexError

* **What is the new behavior (if this is a feature change)?**

Tests pass

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

Tested on Ubuntu 20.04, with python 3.7