### PR TITLE
Freezes setuptool version to 57.5 since newer version breaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools==57.5.0
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Run unit-tests (Linux)

--- a/README.md
+++ b/README.md
@@ -20,17 +20,19 @@ Python 3 compatible, a single version will be tested for each release to ensure 
 The supported version for the next release is Python 3.8. To run the source:
 
 1. Download the repository
-2. Install dependencies
-        
+2. For Windows, download and install [Microsoft Visual C++](https://aka.ms/vs/16/release/vc_redist.x64.exe)
+3. Install dependencies
+            
+        pip install setuptools==57.5.0
         pip install -r requirements.txt
         pip install -r requirements-dev.txt  # optional for development only
-3. Add the following line in **main.py** after the ``import sys`` statement  
+4. Add the following line in **sscanss/app/main.py** after the ``import sys`` statement  
 
         import os
         sys.path.append(os.path.abspath('..')) 
-4. Open a terminal and navigate to the **SScanSS-2** directory then  
+5. Open a terminal and navigate to the **SScanSS-2** directory then  
         
-        cd sscanss
+        cd sscanss/app
         python main.py
 
 


### PR DESCRIPTION
Newer version of setuptools breaks build of pystache. This fixes the issue and updates readme