### PR TITLE
Removing duplicate message types

### DIFF
--- a/sscanss/app/commands/insert.py
+++ b/sscanss/app/commands/insert.py
@@ -7,7 +7,7 @@ from sscanss.core.geometry import (create_tube, create_sphere, create_cylinder, 
                                    closest_triangle_to_point, compute_face_normals)
 from sscanss.core.io import read_angles, create_data_from_tiffs, read_tomoproc_hdf
 from sscanss.core.math import matrix_from_pose
-from sscanss.core.util import (Primitives, Worker, PointType, LoadVector, MessageSeverity, StrainComponents, CommandID,
+from sscanss.core.util import (Primitives, Worker, PointType, LoadVector, MessageType, StrainComponents, CommandID,
                                Attributes, InsertSampleOptions)
 
 
@@ -664,11 +664,11 @@ class InsertVectorsFromFile(QtWidgets.QUndoCommand):
         if return_code == LoadVector.Smaller_than_points:
             msg = 'Fewer measurements vectors than points were loaded from the file. The remaining have been ' \
                   'assigned a zero vector.'
-            self.presenter.view.showMessage(msg, MessageSeverity.Information)
+            self.presenter.view.showMessage(msg, MessageType.Information)
         elif return_code == LoadVector.Larger_than_points:
             msg = 'More measurements vectors than points were loaded from the file. The extra vectors have been  ' \
                   'added as secondary alignments.'
-            self.presenter.view.showMessage(msg, MessageSeverity.Information)
+            self.presenter.view.showMessage(msg, MessageType.Information)
 
         self.presenter.view.docks.showVectorManager()
 
@@ -750,11 +750,11 @@ class CreateVectorsWithEulerAngles(QtWidgets.QUndoCommand):
         if return_code == LoadVector.Smaller_than_points:
             msg = 'Fewer euler angles than points were loaded from the file. The empty vectors have been ' \
                   'assigned a zero vector.'
-            self.presenter.view.showMessage(msg, MessageSeverity.Information)
+            self.presenter.view.showMessage(msg, MessageType.Information)
         elif return_code == LoadVector.Larger_than_points:
             msg = 'More euler angles than points were loaded from the file. The extra vectors have been  ' \
                   'added as secondary alignments.'
-            self.presenter.view.showMessage(msg, MessageSeverity.Information)
+            self.presenter.view.showMessage(msg, MessageType.Information)
 
         self.presenter.view.docks.showVectorManager()
 

--- a/sscanss/app/dialogs/misc.py
+++ b/sscanss/app/dialogs/misc.py
@@ -956,7 +956,7 @@ class SimulationDialog(QtWidgets.QWidget):
         :param details: pane details
         :type details: QtWidgets.QWidget
         :param style: pane type
-        :type style: Pane.Type
+        :type style: MessageType
         :param result: simulation result
         :type result: SimulationResult
         :return: accordion pane

--- a/sscanss/app/dialogs/misc.py
+++ b/sscanss/app/dialogs/misc.py
@@ -8,7 +8,7 @@ from matplotlib.figure import Figure
 from sscanss.config import path_for, __version__, settings
 from sscanss.core.instrument import IKSolver
 from sscanss.core.util import (DockFlag, Attributes, Accordion, Pane, create_tool_button, Banner, compact_path,
-                               StyledTabWidget)
+                               StyledTabWidget, MessageType)
 from sscanss.app.widgets import AlignmentErrorModel, ErrorDetailModel, CenteredBoxProxy
 
 
@@ -315,7 +315,7 @@ class AlignmentErrorDialog(QtWidgets.QDialog):
         self.end_configuration = end_configuration
 
         self.main_layout = QtWidgets.QVBoxLayout()
-        self.banner = Banner(Banner.Type.Info, self)
+        self.banner = Banner(MessageType.Information, self)
         self.main_layout.addWidget(self.banner)
         self.banner.hide()
 
@@ -363,7 +363,7 @@ class AlignmentErrorDialog(QtWidgets.QDialog):
         self.updateModel(indices, enabled)
         if order_fix is not None:
             self.banner.actionButton('FIX', lambda ignore, n=order_fix: self.__correctIndexOrder(n))
-            self.banner.showMessage('Incorrect Point Indices have been detected.', Banner.Type.Warn, False)
+            self.banner.showMessage('Incorrect Point Indices have been detected.', MessageType.Warning, False)
 
     def createTabWidgets(self):
         """Creates the tab widget"""
@@ -415,7 +415,7 @@ class AlignmentErrorDialog(QtWidgets.QDialog):
     def recalculate(self):
         """Recalculates the alignment error"""
         if np.count_nonzero(self.summary_table_model.enabled) < 3:
-            self.banner.showMessage('A minimum of 3 points is required for sample alignment.', Banner.Type.Error)
+            self.banner.showMessage('A minimum of 3 points is required for sample alignment.', MessageType.Error)
             return
 
         self.transform_result = self.parent().presenter.rigidTransform(self.summary_table_model.point_index,
@@ -459,7 +459,7 @@ class AlignmentErrorDialog(QtWidgets.QDialog):
             colour = 'firebrick'
             self.banner.showMessage(
                 'If the errors are larger than desired, '
-                'Try disabling points with the large errors then recalculate.', Banner.Type.Info)
+                'Try disabling points with the large errors then recalculate.', MessageType.Information)
         self.result_label.setText(self.result_text.format(colour, average_error, 'mm'))
 
     def updateModel(self, indices, enabled):
@@ -684,7 +684,7 @@ class SimulationDialog(QtWidgets.QWidget):
         self.parent_model = parent.presenter.model
         main_layout = QtWidgets.QVBoxLayout()
 
-        self.banner = Banner(Banner.Type.Info, self)
+        self.banner = Banner(MessageType.Information, self)
         main_layout.addWidget(self.banner)
         self.banner.hide()
         main_layout.addSpacing(10)
@@ -907,12 +907,12 @@ class SimulationDialog(QtWidgets.QWidget):
                 header = self.__createPaneHeader(
                     f'<span>{result.id}</span><br/> '
                     f'<span><b>SKIPPED:</b> {result.note}.</span>', None)
-                style = Pane.Type.Info
+                style = MessageType.Information
             elif result.ik.status == IKSolver.Status.Failed:
                 header = self.__createPaneHeader(
                     f'<span>{result.id}</span><br/><span> A runtime error occurred. '
                     'Check logs for more Information.</span>', result.ik.status)
-                style = Pane.Type.Error
+                style = MessageType.Error
             else:
                 result_text = '\n'.join('{:<20}{:>12.3f}'.format(*t)
                                         for t in zip(result.joint_labels, result.formatted))
@@ -932,9 +932,9 @@ class SimulationDialog(QtWidgets.QWidget):
 
                 show_collision = self.simulation.check_collision and np.any(result.collision_mask)
                 if result.ik.status == IKSolver.Status.Converged and not show_collision:
-                    style = Pane.Type.Info
+                    style = MessageType.Information
                 else:
-                    style = Pane.Type.Warn
+                    style = MessageType.Warning
 
                 header = self.__createPaneHeader(info, result.ik.status, show_collision)
                 details.setText(f'<pre>{result_text}</pre>')
@@ -969,7 +969,7 @@ class SimulationDialog(QtWidgets.QWidget):
         if not self.filter_button_group.button(key.value).isChecked():
             pane.setHidden(True)
 
-        if style == Pane.Type.Error or result.skipped:
+        if style == MessageType.Error or result.skipped:
             pane.setDisabled(True)
             pane.toggle_icon.hide()
             return pane
@@ -1066,7 +1066,7 @@ class SimulationDialog(QtWidgets.QWidget):
             if positioner.name != self.simulation.positioner_name:
                 self.banner.showMessage(
                     f'Simulation cannot be visualized because positioning system '
-                    f'("{self.simulation.positioner_name}") was changed.', Banner.Type.Error)
+                    f'("{self.simulation.positioner_name}") was changed.', MessageType.Error)
                 return
 
             self.__movePositioner(result.ik.q)
@@ -1078,7 +1078,7 @@ class SimulationDialog(QtWidgets.QWidget):
                     or not self.simulation.validateInstrumentParameters(self.parent_model.instrument)):
                 self.banner.showMessage(
                     'Collision results could be incorrect because sample, jaw or detector was'
-                    ' moved/changed', Banner.Type.Warn)
+                    ' moved/changed', MessageType.Warning)
                 return
 
             self.parent.scenes.renderCollision(result.collision_mask)

--- a/sscanss/app/dialogs/tools.py
+++ b/sscanss/app/dialogs/tools.py
@@ -3,7 +3,8 @@ from PyQt5 import QtCore, QtWidgets
 from sscanss.config import path_for
 from sscanss.core.geometry import BoundingBox, point_selection
 from sscanss.core.math import is_close, Matrix44, Plane, rotation_btw_vectors, Vector3
-from sscanss.core.util import TransformType, DockFlag, PlaneOptions, create_tool_button, FormControl, FormGroup, Banner
+from sscanss.core.util import (TransformType, DockFlag, PlaneOptions, create_tool_button, FormControl, FormGroup,
+                               Banner, MessageType)
 
 
 class TransformDialog(QtWidgets.QWidget):
@@ -24,7 +25,7 @@ class TransformDialog(QtWidgets.QWidget):
         self.type = transform_type
 
         self.main_layout = QtWidgets.QVBoxLayout()
-        self.banner = Banner(Banner.Type.Info, self)
+        self.banner = Banner(MessageType.Information, self)
         self.main_layout.addWidget(self.banner)
         self.banner.hide()
         self.main_layout.addSpacing(10)
@@ -73,7 +74,7 @@ class TransformDialog(QtWidgets.QWidget):
 
         if self.parent_model.sample and self.parent_model.fiducials.size == 0:
             self.banner.showMessage('It is recommended to add fiducial points before transforming the sample.',
-                                    Banner.Type.Info)
+                                    MessageType.Information)
 
     def closeEvent(self, event):
         self.tool.close()

--- a/sscanss/app/window/view.py
+++ b/sscanss/app/window/view.py
@@ -11,7 +11,7 @@ from sscanss.config import settings, path_for, DOCS_URL, __version__, UPDATE_URL
 from sscanss.app.dialogs import (ProgressDialog, ProjectDialog, Preferences, AlignmentErrorDialog, SampleExportDialog,
                                  ScriptExportDialog, PathLengthPlotter, AboutDialog, CalibrationErrorDialog)
 from sscanss.core.scene import Node, OpenGLRenderer, SceneManager
-from sscanss.core.util import (Primitives, Directions, TransformType, PointType, MessageSeverity, Attributes,
+from sscanss.core.util import (Primitives, Directions, TransformType, PointType, MessageType, Attributes,
                                toggle_action_in_group, StatusBar, FileDialog, MessageReplyType)
 
 MAIN_WINDOW_TITLE = 'SScanSS 2'
@@ -782,14 +782,14 @@ class MainWindow(QtWidgets.QMainWindow):
         """Opens the path length plotter dialog"""
         simulation = self.presenter.model.simulation
         if simulation is None:
-            self.showMessage('There are no simulation results.', MessageSeverity.Information)
+            self.showMessage('There are no simulation results.', MessageType.Information)
             return
 
         if not simulation.compute_path_length:
             self.showMessage(
                 'Path Length computation is not enabled for this simulation.\n'
                 'Go to "Simulation > Compute Path Length" to enable it then \nrestart simulation.',
-                MessageSeverity.Information)
+                MessageType.Information)
             return
 
         path_length_plotter = PathLengthPlotter(self)
@@ -808,16 +808,16 @@ class MainWindow(QtWidgets.QMainWindow):
         """Shows the dialog for exporting the resulting script from a simulation"""
         simulation = self.presenter.model.simulation
         if simulation is None:
-            self.showMessage('There are no simulation results to write in script.', MessageSeverity.Information)
+            self.showMessage('There are no simulation results to write in script.', MessageType.Information)
             return
 
         if simulation.isRunning():
             self.showMessage('Finish or Stop the current simulation before attempting to write script.',
-                             MessageSeverity.Information)
+                             MessageType.Information)
             return
 
         if not simulation.has_valid_result:
-            self.showMessage('There are no valid simulation results to write in script.', MessageSeverity.Information)
+            self.showMessage('There are no valid simulation results to write in script.', MessageType.Information)
             return
 
         script_export = ScriptExportDialog(simulation, parent=self)
@@ -866,17 +866,17 @@ class MainWindow(QtWidgets.QMainWindow):
         filename = FileDialog.getOpenFileName(self, title, directory, filters)
         return filename
 
-    def showMessage(self, message, severity=MessageSeverity.Critical):
+    def showMessage(self, message, severity=MessageType.Error):
         """Shows a message with a given severity.
 
         :param message: user message
         :type message: str
         :param severity: severity of the message
-        :type severity: MessageSeverity
+        :type severity: MessageType
         """
-        if severity == MessageSeverity.Critical:
+        if severity == MessageType.Error:
             QtWidgets.QMessageBox.critical(self, MAIN_WINDOW_TITLE, message)
-        elif severity == MessageSeverity.Warning:
+        elif severity == MessageType.Warning:
             QtWidgets.QMessageBox.warning(self, MAIN_WINDOW_TITLE, message)
         else:
             QtWidgets.QMessageBox.information(self, MAIN_WINDOW_TITLE, message)

--- a/sscanss/core/instrument/simulation.py
+++ b/sscanss/core/instrument/simulation.py
@@ -70,7 +70,7 @@ class SharedArray:
         :rtype: numpy.ndarray
         """
         if array.data_type == bool:
-            data = np.frombuffer(array.data, dtype=np.int8).reshape(array.shape).astype(np.bool)
+            data = np.frombuffer(array.data, dtype=np.int8).reshape(array.shape).astype(bool)
         else:
             data = np.frombuffer(array.data, dtype=array.data_type).reshape(array.shape)
         return data

--- a/sscanss/core/util/__init__.py
+++ b/sscanss/core/util/__init__.py
@@ -1,5 +1,5 @@
 from .misc import (Directions, Primitives, to_float, TransformType, DockFlag, PointType, Attributes, POINT_DTYPE,
-                   StrainComponents, LoadVector, MessageSeverity, CommandID, toggle_action_in_group, PlaneOptions,
+                   StrainComponents, LoadVector, MessageType, CommandID, toggle_action_in_group, PlaneOptions,
                    compact_path, find_duplicates, MessageReplyType, InsertSampleOptions)
 from .worker import Worker
 from .forms import FormGroup, FormControl, CompareValidator, Banner, FormTitle

--- a/sscanss/core/util/forms.py
+++ b/sscanss/core/util/forms.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from enum import Enum, unique
 from PyQt5 import QtCore, QtGui, QtWidgets
 from .misc import to_float
+from sscanss.core.util import MessageType
 
 
 class Validator(ABC):
@@ -487,19 +488,12 @@ class Banner(QtWidgets.QWidget):
     """ Creates Banner widget to display colour coded message in a parent widget.
     The widget background colour is blue for Info, yellow for Warn, and red for Error message types
 
-    :param message_type: type of message
-    :type message_type: Banner.Type
+    :param banner_type: type of message on banner
+    :type banner_type: MessageType
     :param parent: parent widget
     :type parent: QtWidgets.QWidget
     """
-    @unique
-    class Type(Enum):
-        """Type of information in Banner"""
-        Info = 1
-        Warn = 2
-        Error = 3
-
-    def __init__(self, message_type, parent):
+    def __init__(self, banner_type, parent):
         super().__init__(parent)
 
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
@@ -519,7 +513,7 @@ class Banner(QtWidgets.QWidget):
         layout.addWidget(self.action_button)
         layout.addWidget(self.close_button)
         self.setLayout(layout)
-        self.setType(message_type)
+        self.setType(banner_type)
 
     def paintEvent(self, event):
         opt = QtWidgets.QStyleOption()
@@ -529,15 +523,15 @@ class Banner(QtWidgets.QWidget):
 
         super().paintEvent(event)
 
-    def setType(self, message_type):
+    def setType(self, banner_type):
         """Sets the message type of the Banner
 
-        :param message_type: type of message
-        :type message_type: Banner.Type
+        :param banner_type: type of message on banner
+        :type banner_type: MessageType
         """
-        if message_type == self.Type.Error:
+        if banner_type == MessageType.Error:
             style = 'Error-Banner'
-        elif message_type == self.Type.Warn:
+        elif banner_type == MessageType.Warning:
             style = 'Warning-Banner'
         else:
             style = 'Info-Banner'
@@ -546,18 +540,18 @@ class Banner(QtWidgets.QWidget):
         self.setStyle(self.style())
         self.setStyleSheet(self.styleSheet())
 
-    def showMessage(self, message, message_type=Type.Info, no_action=True):
+    def showMessage(self, message, banner_type=MessageType.Information, no_action=True):
         """Shows banner with given message. The action button will be shown if no_action is False
 
         :param message: message text
         :type message: str
-        :param message_type: type of message
-        :type message_type: Banner.Type
+        :param banner_type: type of message on banner
+        :type banner_type: MessageType
         :param no_action: indicates if action button is hidden
         :type no_action: bool
         """
         self.message_label.setText(message)
-        self.setType(message_type)
+        self.setType(banner_type)
 
         if not no_action and self.action_button.isHidden():
             self.action_button.show()

--- a/sscanss/core/util/forms.py
+++ b/sscanss/core/util/forms.py
@@ -488,12 +488,12 @@ class Banner(QtWidgets.QWidget):
     """ Creates Banner widget to display colour coded message in a parent widget.
     The widget background colour is blue for Info, yellow for Warn, and red for Error message types
 
-    :param banner_type: type of message on banner
-    :type banner_type: MessageType
+    :param message_type: type of message on banner
+    :type message_type: MessageType
     :param parent: parent widget
     :type parent: QtWidgets.QWidget
     """
-    def __init__(self, banner_type, parent):
+    def __init__(self, message_type, parent):
         super().__init__(parent)
 
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
@@ -513,7 +513,7 @@ class Banner(QtWidgets.QWidget):
         layout.addWidget(self.action_button)
         layout.addWidget(self.close_button)
         self.setLayout(layout)
-        self.setType(banner_type)
+        self.setType(message_type)
 
     def paintEvent(self, event):
         opt = QtWidgets.QStyleOption()
@@ -523,15 +523,15 @@ class Banner(QtWidgets.QWidget):
 
         super().paintEvent(event)
 
-    def setType(self, banner_type):
+    def setType(self, message_type):
         """Sets the message type of the Banner
 
-        :param banner_type: type of message on banner
-        :type banner_type: MessageType
+        :param message_type: type of message on banner
+        :type message_type: MessageType
         """
-        if banner_type == MessageType.Error:
+        if message_type == MessageType.Error:
             style = 'Error-Banner'
-        elif banner_type == MessageType.Warning:
+        elif message_type == MessageType.Warning:
             style = 'Warning-Banner'
         else:
             style = 'Info-Banner'
@@ -540,18 +540,18 @@ class Banner(QtWidgets.QWidget):
         self.setStyle(self.style())
         self.setStyleSheet(self.styleSheet())
 
-    def showMessage(self, message, banner_type=MessageType.Information, no_action=True):
+    def showMessage(self, message, message_type=MessageType.Information, no_action=True):
         """Shows banner with given message. The action button will be shown if no_action is False
 
         :param message: message text
         :type message: str
-        :param banner_type: type of message on banner
-        :type banner_type: MessageType
+        :param message_type: type of message on banner
+        :type message_type: MessageType
         :param no_action: indicates if action button is hidden
         :type no_action: bool
         """
         self.message_label.setText(message)
-        self.setType(banner_type)
+        self.setType(message_type)
 
         if not no_action and self.action_button.isHidden():
             self.action_button.show()

--- a/sscanss/core/util/misc.py
+++ b/sscanss/core/util/misc.py
@@ -98,7 +98,7 @@ class LoadVector(Enum):
 
 @unique
 class MessageType(Enum):
-    """Type of displayed message: information, warning or error"""
+    """Type of displayed message"""
     Information = 1
     Warning = 2
     Error = 3

--- a/sscanss/core/util/misc.py
+++ b/sscanss/core/util/misc.py
@@ -97,11 +97,11 @@ class LoadVector(Enum):
 
 
 @unique
-class MessageSeverity(Enum):
-    """Severity of the message box information"""
+class MessageType(Enum):
+    """Type of displayed message: information, warning or error"""
     Information = 1
     Warning = 2
-    Critical = 3
+    Error = 3
 
 
 @unique

--- a/sscanss/core/util/widgets.py
+++ b/sscanss/core/util/widgets.py
@@ -1,8 +1,8 @@
-from enum import Enum, unique
 import os
 import re
 from PyQt5 import QtGui, QtWidgets, QtCore
 from ...config import path_for
+from sscanss.core.util import MessageType
 
 
 def create_icon(colour, size):
@@ -207,16 +207,9 @@ class Pane(QtWidgets.QWidget):
     :param pane_content: widget to embed as pane content
     :type pane_content: QtWidgets.QLabel
     :param pane_type: pane type
-    :type pane_type: Pane.Type
+    :type pane_type: MessageType
     """
-    @unique
-    class Type(Enum):
-        """Type of information in Pane"""
-        Info = 1
-        Warn = 2
-        Error = 3
-
-    def __init__(self, pane_widget, pane_content, pane_type=Type.Info):
+    def __init__(self, pane_widget, pane_content, pane_type=MessageType.Information):
         super().__init__()
 
         main_layout = QtWidgets.QVBoxLayout()
@@ -259,11 +252,11 @@ class Pane(QtWidgets.QWidget):
         """Sets pane style for the given type
 
         :param pane_type: pane type
-        :type pane_type: Pane.Type
+        :type pane_type: MessageType
         """
-        if pane_type == self.Type.Error:
+        if pane_type == MessageType.Error:
             style_name = 'Error-Pane'
-        elif pane_type == self.Type.Warn:
+        elif pane_type == MessageType.Warning:
             style_name = 'Warning-Pane'
         else:
             style_name = 'Normal-Pane'

--- a/sscanss/core/util/widgets.py
+++ b/sscanss/core/util/widgets.py
@@ -206,10 +206,10 @@ class Pane(QtWidgets.QWidget):
     :type pane_widget: QtWidgets.QLabel
     :param pane_content: widget to embed as pane content
     :type pane_content: QtWidgets.QLabel
-    :param pane_type: pane type
-    :type pane_type: MessageType
+    :param message_type: message type
+    :type message_type: MessageType
     """
-    def __init__(self, pane_widget, pane_content, pane_type=MessageType.Information):
+    def __init__(self, pane_widget, pane_content, message_type=MessageType.Information):
         super().__init__()
 
         main_layout = QtWidgets.QVBoxLayout()
@@ -234,7 +234,7 @@ class Pane(QtWidgets.QWidget):
         main_layout.addWidget(self.content)
 
         self.toggle(True)
-        self.setStyle(pane_type)
+        self.setStyle(message_type)
 
         self.context_menu = QtWidgets.QMenu()
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
@@ -248,15 +248,15 @@ class Pane(QtWidgets.QWidget):
 
         super().paintEvent(event)
 
-    def setStyle(self, pane_type):
+    def setStyle(self, message_type):
         """Sets pane style for the given type
 
-        :param pane_type: pane type
-        :type pane_type: MessageType
+        :param message_type: message type
+        :type message_type: MessageType
         """
-        if pane_type == MessageType.Error:
+        if message_type == MessageType.Error:
             style_name = 'Error-Pane'
-        elif pane_type == MessageType.Warning:
+        elif message_type == MessageType.Warning:
             style_name = 'Warning-Pane'
         else:
             style_name = 'Normal-Pane'

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -369,10 +369,10 @@ class TestSimulationHelpers(unittest.TestCase):
         self.assertEqual(array.dtype, np.int32)
         np.testing.assert_array_equal(data, array)
 
-        shared = SharedArray.fromNumpyArray(np.array([[True], [False], [True]], np.bool))
+        shared = SharedArray.fromNumpyArray(np.array([[True], [False], [True]], bool))
         array = SharedArray.toNumpyArray(shared)
         self.assertEqual(array.shape, (3, 1))
-        self.assertEqual(array.dtype, np.bool)
+        self.assertEqual(array.dtype, bool)
         np.testing.assert_array_equal([[True], [False], [True]], array)
 
         self.assertRaises(ValueError, SharedArray.fromNumpyArray, np.array(data, np.int64))

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -11,7 +11,7 @@ from sscanss.core.instrument.robotics import IKSolver, IKResult, SerialManipulat
 from sscanss.core.instrument.instrument import Script, PositioningStack
 from sscanss.core.scene import OpenGLRenderer, SceneManager
 from sscanss.core.util import (StatusBar, ColourPicker, FileDialog, FilePicker, Accordion, Pane, FormControl, FormGroup,
-                               CompareValidator, StyledTabWidget)
+                               CompareValidator, StyledTabWidget, MessageType)
 from sscanss.app.dialogs import (SimulationDialog, ScriptExportDialog, PathLengthPlotter, SampleExportDialog,
                                  SampleManager, PointManager, VectorManager, DetectorControl, JawControl,
                                  PositionerControl, TransformDialog, AlignmentErrorDialog, CalibrationErrorDialog,
@@ -1488,8 +1488,8 @@ class TestAccordion(unittest.TestCase):
         self.context_menu_visible = True
 
     def testAddAndClear(self):
-        pane_1 = Pane(QLabel(), QLabel(), Pane.Type.Warn)
-        pane_2 = Pane(QLabel(), QLabel(), Pane.Type.Error)
+        pane_1 = Pane(QLabel(), QLabel(), MessageType.Warning)
+        pane_2 = Pane(QLabel(), QLabel(), MessageType.Error)
 
         accordion = Accordion()
         accordion.addPane(pane_1)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce(Bug fix, feature, docs update, ...)?** 
Refactor to remove duplication of message types. Closes Issue #26 


* **What is the current behaviour (You can also link to an open issue here)?**
MessageSeverity, Banner.Type and Pane.Type all have defined Enums for types: Information, Warning, or Error



* **What is the new behaviour (if this is a feature change)?**
These three have all been removed and replaced with a MessageType Class


* **Does this PR introduce a breaking change (What changes might users need to make in their application due to this PR)?**
No


* **Other information:**
