### PR TITLE
Volume point picking

### DIFF
--- a/docs/add_measurements.rst
+++ b/docs/add_measurements.rst
@@ -38,8 +38,9 @@ the window is closed.
 
 Graphics view
 =============
-The 2D path from the cross-section of a plane with the sample is shown in the graphic view. Measurement points on
-the cross-section plane will be also be shown. Above the graphics view is a tool bar with a few buttons:
+The 2D path (for mesh sample) or slice (for volume sample) from the cross-section of a plane with the sample is shown
+in the graphic view. Measurement points on the cross-section plane will be also be shown. Above the graphics view is a
+tool bar with a few buttons:
 
 * The **Add Points** button inserts points that have been placed in the graphics view into the project.
 * The |reset| button resets the graphic view's camera.

--- a/sscanss/app/widgets/__init__.py
+++ b/sscanss/app/widgets/__init__.py
@@ -1,2 +1,2 @@
-from .graphics import GraphicsView, GraphicsScene, GraphicsPointItem, Grid
+from .graphics import GraphicsView, GraphicsScene, GraphicsPointItem, Grid, GraphicsImageItem
 from .table_model import PointModel, AlignmentErrorModel, ErrorDetailModel, CenteredBoxProxy, LimitTextDelegate

--- a/sscanss/app/widgets/graphics.py
+++ b/sscanss/app/widgets/graphics.py
@@ -552,6 +552,58 @@ class GraphicsPointItem(QtWidgets.QAbstractGraphicsShapeItem):
             painter.restore()
 
 
+class GraphicsImageItem(QtWidgets.QAbstractGraphicsShapeItem):
+    """Creates a shape item for an image in graphics view. The image is drawn
+    inside the given rectangle.
+
+    :param rect: image rectangle
+    :type rect: QtCore.QRectF
+    :param image: image data
+    :type image: numpy.ndarray
+    """
+    def __init__(self, rect, image, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+        self.rect = rect
+        self.image = self.toQImage(image)
+
+    @staticmethod
+    def toQImage(array):
+        """Converts numpy array to QImage
+
+        :param array: grayscale image
+        :type array: numpy.ndarray
+        :return: Qt image
+        :rtype: QImage
+        """
+        height, width = array.shape
+        img = array.shape
+        if array.dtype == np.uint16:
+            img = (array / 256).astype(np.uint8)
+        elif array.dtype == np.float32:
+            img = (array * 255).astype(np.uint8)
+        image = QtGui.QImage(img.data, width, height, QtGui.QImage.Format_Indexed8)
+        for i in range(256):
+            image.setColor(i, QtGui.QColor(i, i, i, 150).rgba())
+
+        return image
+
+    def boundingRect(self):
+        """Returns the bounding box of the graphics item
+
+        :return: bounding rect
+        :rtype: QtCore.QRect
+        """
+        return self.rect
+
+    def paint(self, painter, _options, _widget):
+        pen = self.pen()
+        painter.setPen(pen)
+        painter.setBrush(self.brush())
+
+        painter.drawImage(self.rect, self.image)
+
+
 class Grid(ABC):
     """Base class for form graphics view grid """
     @unique

--- a/sscanss/core/geometry/__init__.py
+++ b/sscanss/core/geometry/__init__.py
@@ -1,6 +1,7 @@
 from .primitive import create_cuboid, create_cylinder, create_sphere, create_tube, create_plane
 from .intersection import (closest_triangle_to_point, mesh_plane_intersection, segment_triangle_intersection,
-                           segment_plane_intersection, path_length_calculation, point_selection)
+                           segment_plane_intersection, path_length_calculation, point_selection,
+                           volume_plane_intersection)
 from .mesh import Mesh, MeshGroup, compute_face_normals, BoundingBox
 from .colour import Colour
 from .volume import Volume, Curve

--- a/sscanss/core/math/__init__.py
+++ b/sscanss/core/math/__init__.py
@@ -4,6 +4,6 @@ from .structure import Plane, fit_line_3d, fit_circle_3d, fit_circle_2d
 from .matrix import Matrix, Matrix33, Matrix44
 from .transform import (angle_axis_to_matrix, xyz_eulers_from_matrix, matrix_from_xyz_eulers, rotation_btw_vectors,
                         rigid_transform, find_3d_correspondence, matrix_from_pose, angle_axis_btw_vectors,
-                        matrix_to_angle_axis, check_rotation, matrix_from_zyx_eulers)
+                        matrix_to_angle_axis, check_rotation, matrix_from_zyx_eulers, view_from_plane)
 from .quaternion import Quaternion, QuaternionVectorPair
 from .constants import POS_EPS, VECTOR_EPS

--- a/sscanss/core/math/transform.py
+++ b/sscanss/core/math/transform.py
@@ -11,6 +11,28 @@ from .matrix import Matrix33, Matrix44
 from .misc import clamp, is_close
 
 
+def view_from_plane(plane_normal):
+    """Computes the matrix for viewing a plane from its normal
+
+    :param  plane_normal: plane normal
+    :type plane_normal: numpy.ndarray
+    :return: view in plane
+    :rtype: Matrix33
+    """
+    plane_normal = -Vector3(plane_normal)
+    rot_matrix = Matrix33.identity()
+    up = Vector3([0., -1., 0.]) if -VECTOR_EPS < plane_normal[1] < VECTOR_EPS else Vector3([0., 0., 1.])
+    left = up ^ plane_normal
+    left.normalize()
+    up = plane_normal ^ left
+
+    rot_matrix.c1[:3] = left
+    rot_matrix.c2[:3] = up
+    rot_matrix.c3[:3] = plane_normal
+
+    return rot_matrix
+
+
 def check_rotation(matrix):
     """Checks that the matrix is a valid rotation matrix i.e no scaling, shearing
 

--- a/sscanss/core/scene/entity.py
+++ b/sscanss/core/scene/entity.py
@@ -42,11 +42,11 @@ class SampleEntity(Entity):
 
         if isinstance(self._sample, Mesh):
             sample_node = Node(self._sample)
-            sample_node.render_mode = render_mode
             sample_node.colour = Colour(*settings.value(settings.Key.Sample_Colour))
         elif isinstance(self._sample, Volume):
             sample_node = VolumeRenderNode(self._sample)
 
+        sample_node.render_mode = render_mode
         sample_node.buildVertexBuffer()
         return sample_node
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -5,10 +5,19 @@ from sscanss.core.math import (Vector, Vector2, Vector3, Vector4, Matrix, Matrix
                                angle_axis_to_matrix, xyz_eulers_from_matrix, matrix_from_xyz_eulers, Quaternion,
                                QuaternionVectorPair, rigid_transform, find_3d_correspondence, matrix_to_angle_axis,
                                matrix_from_pose, rotation_btw_vectors, angle_axis_btw_vectors, fit_line_3d,
-                               fit_circle_3d, fit_circle_2d, matrix_from_zyx_eulers)
+                               fit_circle_3d, fit_circle_2d, matrix_from_zyx_eulers, view_from_plane)
 
 
 class TestMath(unittest.TestCase):
+    def testViewFromPlane(self):
+        expected = [[1., 0., 0.], [0., -1., 0.], [0., 0., -1.]]
+        matrix = view_from_plane(np.array([0, 0, 1]))
+        np.testing.assert_array_almost_equal(matrix, expected, decimal=5)
+
+        expected = [[0.7071068, 0., -0.7071068], [0., -1., 0.], [-0.7071068, 0., -0.7071068]]
+        matrix = view_from_plane(np.array([0.7071068, 0, 0.7071068]))
+        np.testing.assert_array_almost_equal(matrix, expected, decimal=5)
+
     def testCheckRotation(self):
         self.assertFalse(check_rotation(np.array([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]])))
         self.assertFalse(check_rotation(10 * np.identity(4)))


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce(Bug fix, feature, docs update, ...)?** 
Updates the point selection widget to select points on a slice of a volume sample


* **What is the current behaviour (You can also link to an open issue here)?**
The widget does not work with a volume sample


* **What is the new behaviour (if this is a feature change)?**
The widget work for both meshes and volumes


* **Does this PR introduce a breaking change (What changes might users need to make in their application due to this PR)?**
No


* **Other information:**
Test that measurement points can be selected on the volume slice
  1. Import a volume sample
  2. Open the point selection dialog Insert > Measurement Points >  Graphics Selection
  3. Change the plane (from the dropdown or by dragging the slider)l and check slice is correct
  4. Use selection tools to pick a measurement point on the slice, click 'Add points' button and check that the point is added to the appropriate position in the 3D viewer 

![Screenshot 2022-03-15 100856](https://user-images.githubusercontent.com/34302892/158567662-6573a798-2e50-4d12-a425-1159a24452da.png)

