### PR TITLE
Update widgets.py

### DIFF
--- a/sscanss/editor/widgets.py
+++ b/sscanss/editor/widgets.py
@@ -362,6 +362,7 @@ class PositionerWidget(QtWidgets.QWidget):
             self.parent.instrument.loadPositioningStack(selected)
             self.createForms()
             self.parent.scene.updateInstrumentScene()
+            self.stack_combobox.setCurrentIndex(self.stack_combobox.findText(selected))
 
     def createForms(self):
         """Creates form inputs for main and auxiliary positioners in the positioning stack"""

--- a/sscanss/editor/widgets.py
+++ b/sscanss/editor/widgets.py
@@ -362,7 +362,7 @@ class PositionerWidget(QtWidgets.QWidget):
             self.parent.instrument.loadPositioningStack(selected)
             self.createForms()
             self.parent.scene.updateInstrumentScene()
-            self.stack_combobox.setCurrentIndex(self.stack_combobox.findText(selected))
+            self.stack_combobox.setCurrentText(selected)
 
     def createForms(self):
         """Creates form inputs for main and auxiliary positioners in the positioning stack"""


### PR DESCRIPTION
Fixes #34 :
- Before it would switch to the first option in the Positioning Stack after a change in the editor
- Now it keeps the correct option selected in the drop down menu after changes