### PR TITLE
Create UI for adding and editing Collimator component in Instrument Editor

### DIFF
--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -1145,7 +1145,7 @@ class CollimatorComponent(QtWidgets.QWidget):
 
         # Detectors combobox
         detectors = []
-        detectors_data = instrument_data.get('detector', [])
+        detectors_data = instrument_data.get('detectors', [])
         for data in detectors_data:
             detector_name = data.get('name', '')
             if detector_name:

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -1107,6 +1107,7 @@ class CollimatorComponent(QtWidgets.QWidget):
     def setNewCollimator(self):
         """ When the 'Add New...' option is chosen in the collimator combobox, clear the text."""
         self.collimator_name.clear()
+        self.detector_combobox.setCurrentIndex(0)
         self.x_aperture.clear()
         self.y_aperture.clear()
         self.visuals.reset()

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -991,6 +991,8 @@ class CollimatorComponent(QtWidgets.QWidget):
         self.detector_combobox = QtWidgets.QComboBox()
         layout.addWidget(QtWidgets.QLabel('Detector: '), 1, 0)
         layout.addWidget(self.detector_combobox, 1, 1)
+        self.detector_validation_label = create_required_label()
+        layout.addWidget(self.detector_validation_label, 0, 2)
 
         # Aperture field - array of floats, required
         self.x_aperture = create_validated_line_edit(3)
@@ -1026,6 +1028,23 @@ class CollimatorComponent(QtWidgets.QWidget):
         :rtype: Dict[QtWidgets.QLabel, QtWidgets.QWidget]
         """
         return {
-            self.collimator_name_validation_label: [self.collimator_name_combobox],
+            self.name_validation_label: [self.collimator_name_combobox],
             self.detector_validation_label: [self.detector_combobox]
         }
+
+    def reset(self):
+        """Reset widgets to default values and validation state"""
+        for label, line_edits in self.__required_widgets.items():
+            label.setText('')
+            for line_edit in line_edits:
+                line_edit.clear()
+                line_edit.setStyleSheet('')
+
+        for label, comboboxes in self.__required_comboboxes.items():
+            label.setText('')
+            for combobox in comboboxes:
+                combobox.clear()
+                combobox.setStyleSheet('')
+
+        self.collimator_name_combobox.addItems([self.new_collimator_text])
+        self.visuals.reset()

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -993,7 +993,7 @@ class CollimatorComponent(QtWidgets.QWidget):
         layout.addWidget(QtWidgets.QLabel('Detector: '), 1, 0)
         layout.addWidget(self.detector_combobox, 1, 1)
         self.detector_validation_label = create_required_label()
-        layout.addWidget(self.detector_validation_label, 0, 2)
+        layout.addWidget(self.detector_validation_label, 1, 2)
 
         # Aperture field - array of floats, required
         self.x_aperture = create_validated_line_edit(3)
@@ -1152,11 +1152,17 @@ class CollimatorComponent(QtWidgets.QWidget):
                 detectors.append(detector_name)
         self.detector_combobox.clear()
         self.detector_combobox.addItems([*detectors])
-        detector = collimator_data.get('detector', 'None')
-        if isinstance(detector, str):
-            self.detector_combobox.setCurrentText(detector)
+
+        # Choose a detector if at least one is listed, otherwise display a warning
+        if detectors:
+            detector = collimator_data.get('detector')
+            if isinstance(detector, str):
+                self.detector_combobox.setCurrentText(detector)
+            else:
+                self.detector_combobox.setCurrentIndex(0)
         else:
-            self.detector_combobox.setCurrentIndex(0)
+            self.detector_combobox.setStyleSheet('border: 1px solid red;')
+            self.detector_validation_label.setText('No Detectors!')
 
         # Aperture line edit
         aperture = collimator_data.get('aperture')

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -1006,3 +1006,26 @@ class CollimatorComponent(QtWidgets.QWidget):
         # The visual object contains: pose, colour, and mesh parameters
         self.visuals = VisualSubComponent()
         layout.addWidget(self.visuals, 3, 0, 1, 3)
+
+    @property
+    def __required_widgets(self):
+        """Generates dict of required widget for validation. The key is the validation
+        label and the value is a list of widgets in the same row as the validation label
+
+        :return: dict of labels and input widgets
+        :rtype: Dict[QtWidgets.QLabel, QtWidgets.QWidget]
+        """
+        return {self.aperture_validation_label: [self.x_aperture, self.y_aperture]}
+
+    @property
+    def __required_comboboxes(self):
+        """Generates dict of required comboboxes for validation. The key is the validation
+        label and the value is a list of widgets in the same row as the validation label
+
+        :return: dict of labels and input comboboxes
+        :rtype: Dict[QtWidgets.QLabel, QtWidgets.QWidget]
+        """
+        return {
+            self.collimator_name_validation_label: [self.collimator_name_combobox],
+            self.detector_validation_label: [self.detector_combobox]
+        }

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -1164,3 +1164,36 @@ class CollimatorComponent(QtWidgets.QWidget):
 
         # Visual object
         self.visuals.updateValue(collimator_data.get('visual', {}), folder_path)
+
+    def value(self):
+        """Returns the updated json from the component's inputs
+
+        :return: updated instrument json
+        :rtype: Dict[str, Any]
+        """
+        json_data = {}
+
+        name = self.collimator_name_combobox.currentText()
+        if name:
+            json_data['name'] = name
+
+        detector = self.detector_combobox.currentText()
+        if detector:
+            json_data['detector'] = detector
+
+        x, y = self.x_aperture.text(), self.y_aperture.text()
+        if x and y:
+            json_data['aperture'] = [float(x), float(y), float(z)]
+
+        visual_data = self.visuals.value()
+        if visual_data[self.visuals.key]:
+            json_data.update(visual_data)
+
+        # Place edited collimator within the list of detectors
+        try:
+            self.collimator_list[self.collimator_name_combobox.currentIndex()] = json_data
+        except IndexError:
+            self.collimator_list.append(json_data)
+
+        # Return updated set of collimators
+        return {self.key: self.collimator_list}

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -175,6 +175,8 @@ class VisualSubComponent(QtWidgets.QWidget):
         :param folder_path: path to instrument file folder
         :type folder_path: str
         """
+        self.reset()
+
         pose = json_data.get('pose')
         if pose is not None:
             self.x_translation.setText(f"{safe_get_value(pose, 0, '0.0')}")
@@ -458,6 +460,7 @@ class JawComponent(QtWidgets.QWidget):
         :param folder_path: path to instrument file folder
         :type folder_path: str
         """
+        self.reset()
         instrument_data = json_data.get('instrument', {})
         jaws_data = instrument_data.get('incident_jaws', {})
 
@@ -640,6 +643,7 @@ class GeneralComponent(QtWidgets.QWidget):
         :param folder_path: path to instrument file folder
         :type folder_path: str
         """
+        self.reset()
         instrument_data = json_data.get('instrument', {})
 
         name = instrument_data.get('name')
@@ -776,10 +780,7 @@ class DetectorComponent(QtWidgets.QWidget):
         for label, comboboxes in self.__required_comboboxes.items():
             label.setText('')
             for combobox in comboboxes:
-                combobox.clear()
                 combobox.setStyleSheet('')
-
-        self.detector_name_combobox.addItems([self.new_detector_text])
 
     def validate(self):
         """Validates the required inputs in the component are filled
@@ -842,6 +843,7 @@ class DetectorComponent(QtWidgets.QWidget):
         :param json_data: instrument json
         :type json_data: Dict[str, Any]
         """
+        self.reset()
         self.json = json_data
         instrument_data = json_data.get('instrument', {})
         self.detector_list = instrument_data.get('detectors', [])
@@ -1044,10 +1046,8 @@ class CollimatorComponent(QtWidgets.QWidget):
         for label, comboboxes in self.__required_comboboxes.items():
             label.setText('')
             for combobox in comboboxes:
-                combobox.clear()
                 combobox.setStyleSheet('')
 
-        self.collimator_name_combobox.addItems([self.new_collimator_text])
         self.visuals.reset()
 
     def validate(self):
@@ -1115,6 +1115,7 @@ class CollimatorComponent(QtWidgets.QWidget):
         :param folder_path: path to instrument file folder
         :type folder_path: str
         """
+        self.reset()
         self.json = json_data
         instrument_data = json_data.get('instrument', {})
         self.collimator_list = instrument_data.get('collimators', [])
@@ -1152,8 +1153,6 @@ class CollimatorComponent(QtWidgets.QWidget):
                 detectors.append(detector_name)
         self.detector_combobox.clear()
         self.detector_combobox.addItems([*detectors])
-        self.detector_combobox.setStyleSheet('')
-        self.detector_validation_label.setText('')
 
         # Choose a detector if at least one is listed, otherwise display a warning
         if detectors:

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -1183,7 +1183,7 @@ class CollimatorComponent(QtWidgets.QWidget):
 
         x, y = self.x_aperture.text(), self.y_aperture.text()
         if x and y:
-            json_data['aperture'] = [float(x), float(y), float(z)]
+            json_data['aperture'] = [float(x), float(y)]
 
         visual_data = self.visuals.value()
         if visual_data[self.visuals.key]:

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -1152,6 +1152,8 @@ class CollimatorComponent(QtWidgets.QWidget):
                 detectors.append(detector_name)
         self.detector_combobox.clear()
         self.detector_combobox.addItems([*detectors])
+        self.detector_combobox.setStyleSheet('')
+        self.detector_validation_label.setText('')
 
         # Choose a detector if at least one is listed, otherwise display a warning
         if detectors:

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -62,6 +62,8 @@ class Designer(QtWidgets.QWidget):
             self.component = GeneralComponent()
         elif component_type == Designer.Component.Detector:
             self.component = DetectorComponent()
+        elif component_type == Designer.Component.Collimator:
+            self.component = CollimatorComponent()
 
         self.layout.insertWidget(1, self.component)
 

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -14,6 +14,7 @@ class Designer(QtWidgets.QWidget):
         Jaws = 'Incident Jaws'
         Visual = 'Visual'
         Detector = 'Detector'
+        Collimator = 'Collimator'
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -955,3 +956,53 @@ class DetectorComponent(QtWidgets.QWidget):
             return {self.key: self.detector_list, self.collimator_key: self.collimator_list}
         else:
             return {self.key: self.detector_list}
+
+
+class CollimatorComponent(QtWidgets.QWidget):
+    """Creates a UI for modifying the collimator component of the instrument description"""
+    def __init__(self):
+        super().__init__()
+
+        self.type = Designer.Component.Collimator
+        self.key = 'collimators'
+
+        self.json = {}
+        self.folder_path = '.'
+        self.new_collimator_text = 'Add New...'
+        self.collimator_list = []
+
+        layout = QtWidgets.QGridLayout()
+        self.setLayout(layout)
+
+        # Name field - string, required -- combobox chooses between collimators, and allows renaming
+        self.collimator_name_combobox = QtWidgets.QComboBox()
+        self.collimator_name_combobox.setEditable(True)
+        layout.addWidget(QtWidgets.QLabel('Name: '), 0, 0)
+        layout.addWidget(self.collimator_name_combobox, 0, 1)
+        self.name_validation_label = create_required_label()
+        layout.addWidget(self.name_validation_label, 0, 2)
+
+        # When the collimator is changed, connect to a slot that updates the collimator parameters in the component
+        # The "activated" signal is emitted only when the user selects an option (not programmatically) and is also
+        # emitted when the user re-selects the same option.
+        self.collimator_name_combobox.activated.connect(lambda: self.updateValue(self.json, self.folder_path))
+
+        # Detector field - string from list, required
+        self.detector_combobox = QtWidgets.QComboBox()
+        layout.addWidget(QtWidgets.QLabel('Detector: '), 1, 0)
+        layout.addWidget(self.detector_combobox, 1, 1)
+
+        # Aperture field - array of floats, required
+        self.x_aperture = create_validated_line_edit(3)
+        self.y_aperture = create_validated_line_edit(3)
+        sub_layout = xy_hbox_layout(self.x_diffracted_beam, self.y_diffracted_beam)
+
+        layout.addWidget(QtWidgets.QLabel('Aperture: '), 2, 0)
+        layout.addLayout(sub_layout, 2, 1)
+        self.aperture_validation_label = create_required_label()
+        layout.addWidget(self.aperture_validation_label, 2, 2)
+
+        # Visual field - visual object, optional
+        # The visual object contains: pose, colour, and mesh parameters
+        self.visuals = VisualSubComponent()
+        layout.addWidget(self.visuals, 3, 0, 1, 3)

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -1048,3 +1048,54 @@ class CollimatorComponent(QtWidgets.QWidget):
 
         self.collimator_name_combobox.addItems([self.new_collimator_text])
         self.visuals.reset()
+
+    def validate(self):
+        """Validates the required inputs in the component are filled
+
+        :return: indicates the required inputs are filled
+        :rtype: bool
+        """
+        valid = True
+
+        widgets = self.__required_widgets
+        for label, line_edits in widgets.items():
+            row_valid = True
+            for line_edit in line_edits:
+                if not line_edit.text():
+                    line_edit.setStyleSheet('border: 1px solid red;')
+                    label.setText('Required!')
+                    valid = False
+                    row_valid = False
+                else:
+                    line_edit.setStyleSheet('')
+                    if row_valid:
+                        label.setText('')
+
+        comboboxes = self.__required_comboboxes
+        for label, boxes in comboboxes.items():
+            row_valid = True
+            for combobox in boxes:
+                if not combobox.currentText():
+                    combobox.setStyleSheet('border: 1px solid red;')
+                    label.setText('Required!')
+                    valid = False
+                    row_valid = False
+                else:
+                    combobox.setStyleSheet('')
+                    if row_valid:
+                        label.setText('')
+
+        visual_valid = self.visuals.validate()
+
+        if valid and visual_valid:
+            for label, line_edits in widgets.items():
+                label.setText('')
+                for line_edit in line_edits:
+                    line_edit.setStyleSheet('')
+            for label, boxes in comboboxes.items():
+                label.setText('')
+                for combobox in boxes:
+                    combobox.setStyleSheet('')
+            return True
+        return False
+    

--- a/sscanss/editor/designer.py
+++ b/sscanss/editor/designer.py
@@ -828,7 +828,7 @@ class DetectorComponent(QtWidgets.QWidget):
         return valid
 
     def setNewDetector(self):
-        """ When the '*Add New*' option is chosen in the detector name combobox, clear the text."""
+        """ When the 'Add New...' option is chosen in the detector name combobox, clear the text."""
         self.detector_name_combobox.clearEditText()
         self.x_diffracted_beam.clear()
         self.y_diffracted_beam.clear()
@@ -1098,4 +1098,10 @@ class CollimatorComponent(QtWidgets.QWidget):
                     combobox.setStyleSheet('')
             return True
         return False
-    
+
+    def setNewCollimator(self):
+        """ When the 'Add New...' option is chosen in the collimator name combobox, clear the text."""
+        self.collimator_name_combobox.clearEditText()
+        self.x_aperture.clear()
+        self.y_aperture.clear()
+        self.visuals.reset()

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -160,6 +160,10 @@ class EditorWindow(QtWidgets.QMainWindow):
         self.detector_designer_action.setStatusTip('Add/Updates detector entry')
         self.detector_designer_action.triggered.connect(lambda: self.showDesigner(Designer.Component.Detector))
 
+        self.collimator_designer_action = QtWidgets.QAction('Collimator', self)
+        self.collimator_designer_action.setStatusTip('Add/Updates collimator entry')
+        self.collimator_designer_action.triggered.connect(lambda: self.showDesigner(Designer.Component.Collimator))
+
     def initMenus(self):
         """Creates main menu and sub menus"""
         menu_bar = self.menuBar()
@@ -195,6 +199,7 @@ class EditorWindow(QtWidgets.QMainWindow):
         designer_menu.addAction(self.general_designer_action)
         designer_menu.addAction(self.jaws_designer_action)
         designer_menu.addAction(self.detector_designer_action)
+        designer_menu.addAction(self.collimator_designer_action)
         tool_menu.addAction(self.generate_robot_model_action)
 
         help_menu = menu_bar.addMenu('&Help')

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -720,8 +720,8 @@ class TestEditor(unittest.TestCase):
         self.assertEqual(component.collimator_combobox.currentText(), component.new_collimator_text)
         for label in labels:
             self.assertEqual(label.text(), '')
-        # 2) The detector combobox ?????? should stay as it is ?????
-        self.assertEqual(component.detector_combobox.currentText(), 'North')
+        # 2) The detector combobox should default to the first detector
+        self.assertEqual(component.detector_combobox.currentIndex(), 0)
         # 3) The component should not be declared valid -- because required arguments are not provided
         self.assertFalse(component.validate())
         # 4) The collimator and aperture label text should not remain empty --

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -8,7 +8,8 @@ from sscanss.core.instrument.instrument import Instrument, PositioningStack, Det
 from sscanss.core.instrument.robotics import Link, SerialManipulator
 from sscanss.editor.main import EditorWindow
 from sscanss.editor.widgets import PositionerWidget, JawsWidget, ScriptWidget, DetectorWidget
-from sscanss.editor.designer import Designer, VisualSubComponent, GeneralComponent, JawComponent, DetectorComponent
+from sscanss.editor.designer import (Designer, VisualSubComponent, GeneralComponent, JawComponent, DetectorComponent,
+                                     CollimatorComponent)
 from sscanss.editor.dialogs import CalibrationWidget, Controls, FindWidget
 from tests.helpers import TestSignal, APP, SAMPLE_IDF
 
@@ -593,3 +594,149 @@ class TestEditor(unittest.TestCase):
         new_detectors = ['North', 'West', 'East']
         for index, detector in enumerate(detectors):
             self.assertEqual(detector['name'], new_detectors[index])
+
+    def testCollimatorComponent(self):
+        component = CollimatorComponent()
+        widgets = [component.x_aperture, component.y_aperture]
+        labels = [
+            component.name_validation_label, component.detector_validation_label, component.aperture_validation_label
+        ]
+
+        # Test text fields are empty to begin with
+        for widget in widgets:
+            self.assertEqual(widget.text(), '')
+        self.assertEqual(component.collimator_name_combobox.currentText(), '')
+        self.assertEqual(component.detector_combobox.currentText(), '')
+
+        # Test inputting empty JSON data and updating the component.
+        component.updateValue({}, '')
+        # 1) The fields in the component should remain empty
+        for widget in widgets:
+            self.assertEqual(widget.text(), '')
+        self.assertEqual(component.collimator_name_combobox.currentText(), '')
+        self.assertEqual(component.detector_combobox.currentText(), '')
+        for label in labels:
+            self.assertEqual(label.text(), '')
+        # 2) The component value should be updated to match the input
+        self.assertCountEqual(component.value()[component.key], [{}])
+        # 3) The component should not be declared valid -- because required arguments are not provided
+        self.assertFalse(component.validate())
+        # 4) The label text should not remain empty -- it should give a warning about the required fields
+        for label in labels:
+            self.assertNotEqual(label.text(), '')
+
+        # Test inputting JSON data defined below and updating the component.
+        # There are two detectors, each associated with two collimators
+        json_data = {
+            'instrument': {
+                "detectors": [{
+                    "name": "North",
+                    "default_collimator": "2.0mm",
+                    "diffracted_beam": [0.0, 1.0, 0.0]
+                }, {
+                    "name": "South",
+                    "default_collimator": "2.0mm",
+                    "diffracted_beam": [0.0, -1.0, 0.0]
+                }],
+                "collimators": [
+                    {
+                        "name": "1.0mm",
+                        "detector": "South",
+                        "aperture": [1.0, 200.0],
+                        "visual": {
+                            "pose": [0.0, 0.0, 0.0, 0.0, 0.0, 90.0],
+                            "mesh": "models/collimator_1mm.stl",
+                            "colour": [0.6, 0.6, 0.6]
+                        }
+                    },
+                    {
+                        "name": "2.0mm",
+                        "detector": "South",
+                        "aperture": [2.0, 200.0],
+                        "visual": {
+                            "pose": [0.0, 0.0, 0.0, 0.0, 0.0, 90.0],
+                            "mesh": "models/collimator_2mm.stl",
+                            "colour": [0.6, 0.6, 0.6]
+                        }
+                    },
+                    {
+                        "name": "1.0mm",
+                        "detector": "North",
+                        "aperture": [1.0, 200.0],
+                        "visual": {
+                            "pose": [0.0, 0.0, 0.0, 0.0, 0.0, -90.0],
+                            "mesh": "models/collimator_1mm.stl",
+                            "colour": [0.6, 0.6, 0.6]
+                        }
+                    },
+                    {
+                        "name": "2.0mm",
+                        "detector": "North",
+                        "aperture": [2.0, 200.0],
+                        "visual": {
+                            "pose": [0.0, 0.0, 0.0, 0.0, 0.0, -90.0],
+                            "mesh": "models/collimator_2mm.stl",
+                            "colour": [0.6, 0.6, 0.6]
+                        }
+                    },
+                ]
+            }
+        }
+
+        first_aperture = ['1.0', '200.0']
+        # This should select the first collimator
+        component.updateValue(json_data, '')
+        # 1) The fields in the component should be updated to match the expected result
+        for index, widget in enumerate(widgets):
+            self.assertEqual(widget.text(), first_aperture[index])
+        self.assertEqual(component.collimator_name_combobox.currentText(), '1.0mm')
+        self.assertEqual(component.detector_combobox.currentText(), 'South')
+        # 2) The component value should be updated to match the input
+        self.assertCountEqual(component.value()[component.key], json_data['instrument'][component.key])
+        # 3) The component should be declared valid -- all required arguments are specified
+        self.assertTrue(component.validate())
+        # 4) The label text should remain empty -- as the component is valid
+        for label in labels:
+            self.assertEqual(label.text(), '')
+
+        fourth_aperture = ['2.0', '200.0']
+        # If we switch collimator, this should be recorded in the component
+        component.collimator_name_combobox.setCurrentIndex(3)
+        component.collimator_name_combobox.activated.emit(1)
+        # 1) The fields in the component should be updated to match the expected result
+        for index, widget in enumerate(widgets):
+            self.assertEqual(widget.text(), fourth_aperture[index])
+        self.assertEqual(component.collimator_name_combobox.currentText(), '2.0mm')
+        self.assertEqual(component.detector_combobox.currentText(), 'North')
+
+        # If we switch to the "Add New..." option, text fields should be cleared
+        component.collimator_name_combobox.setCurrentIndex(4)
+        component.collimator_name_combobox.activated.emit(1)
+        # 1) Most of the fields in the component should be cleared
+        for widget in widgets:
+            self.assertEqual(widget.text(), '')
+        self.assertEqual(component.collimator_name_combobox.currentText(), '')
+        for label in labels:
+            self.assertEqual(label.text(), '')
+        # 2) The detector combobox ?????? should stay as it is ?????
+        self.assertEqual(component.detector_combobox.currentText(), 'North')
+        # 3) The component should not be declared valid -- because required arguments are not provided
+        self.assertFalse(component.validate())
+        # 4) The collimator and aperture label text should not remain empty --
+        #    they should give warnings about the required fields
+        self.assertNotEqual(component.name_validation_label.text(), '')
+        self.assertNotEqual(component.aperture_validation_label.text(), '')
+        # 5) The detector label should be empty, as one has been specified
+        self.assertEqual(component.detector_validation_label.text(), '')
+
+        # Add a new collimator
+        component.collimator_name_combobox.setCurrentText('3.0mm')
+        component.x_aperture.setText('3.0')
+        component.y_aperture.setText('200.0')
+        json_data['instrument'].update(component.value())
+        component.updateValue(json_data, '')
+        # 5) When adding the detector, it should appear in the JSON
+        collimators = json_data.get('instrument').get('collimators')
+        new_collimators = ['1.0mm', '2.0mm', '1.0mm', '2.0mm', '3.0mm']
+        for index, collimator in enumerate(collimators):
+            self.assertEqual(collimator['name'], new_collimators[index])

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -597,7 +597,7 @@ class TestEditor(unittest.TestCase):
 
     def testCollimatorComponent(self):
         component = CollimatorComponent()
-        widgets = [component.x_aperture, component.y_aperture]
+        widgets = [component.collimator_name, component.x_aperture, component.y_aperture]
         labels = [
             component.name_validation_label, component.detector_validation_label, component.aperture_validation_label
         ]
@@ -605,7 +605,7 @@ class TestEditor(unittest.TestCase):
         # Test text fields are empty to begin with
         for widget in widgets:
             self.assertEqual(widget.text(), '')
-        self.assertEqual(component.collimator_name_combobox.currentText(), '')
+        self.assertEqual(component.collimator_combobox.currentText(), '')
         self.assertEqual(component.detector_combobox.currentText(), '')
 
         # Test inputting empty JSON data and updating the component.
@@ -613,7 +613,7 @@ class TestEditor(unittest.TestCase):
         # 1) The fields in the component should remain empty
         for widget in widgets:
             self.assertEqual(widget.text(), '')
-        self.assertEqual(component.collimator_name_combobox.currentText(), '')
+        self.assertEqual(component.collimator_combobox.currentText(), component.new_collimator_text)
         self.assertEqual(component.detector_combobox.currentText(), '')
         self.assertEqual(component.name_validation_label.text(), '')
         self.assertEqual(component.aperture_validation_label.text(), '')
@@ -685,13 +685,13 @@ class TestEditor(unittest.TestCase):
             }
         }
 
-        first_aperture = ['1.0', '200.0']
+        first_collimator = ['1.0mm', '1.0', '200.0']
         # This should select the first collimator
         component.updateValue(json_data, '')
         # 1) The fields in the component should be updated to match the expected result
         for index, widget in enumerate(widgets):
-            self.assertEqual(widget.text(), first_aperture[index])
-        self.assertEqual(component.collimator_name_combobox.currentText(), '1.0mm')
+            self.assertEqual(widget.text(), first_collimator[index])
+        self.assertEqual(component.collimator_combobox.currentText(), 'Collimator 1')
         self.assertEqual(component.detector_combobox.currentText(), 'South')
         # 2) The component value should be updated to match the input
         self.assertCountEqual(component.value()[component.key], json_data['instrument'][component.key])
@@ -701,23 +701,23 @@ class TestEditor(unittest.TestCase):
         for label in labels:
             self.assertEqual(label.text(), '')
 
-        fourth_aperture = ['2.0', '200.0']
+        fourth_collimator = ['2.0mm', '2.0', '200.0']
         # If we switch collimator, this should be recorded in the component
-        component.collimator_name_combobox.setCurrentIndex(3)
-        component.collimator_name_combobox.activated.emit(1)
+        component.collimator_combobox.setCurrentIndex(3)
+        component.collimator_combobox.activated.emit(1)
         # 1) The fields in the component should be updated to match the expected result
         for index, widget in enumerate(widgets):
-            self.assertEqual(widget.text(), fourth_aperture[index])
-        self.assertEqual(component.collimator_name_combobox.currentText(), '2.0mm')
+            self.assertEqual(widget.text(), fourth_collimator[index])
+        self.assertEqual(component.collimator_combobox.currentText(), 'Collimator 4')
         self.assertEqual(component.detector_combobox.currentText(), 'North')
 
         # If we switch to the "Add New..." option, text fields should be cleared
-        component.collimator_name_combobox.setCurrentIndex(4)
-        component.collimator_name_combobox.activated.emit(1)
+        component.collimator_combobox.setCurrentIndex(4)
+        component.collimator_combobox.activated.emit(1)
         # 1) Most of the fields in the component should be cleared
         for widget in widgets:
             self.assertEqual(widget.text(), '')
-        self.assertEqual(component.collimator_name_combobox.currentText(), '')
+        self.assertEqual(component.collimator_combobox.currentText(), component.new_collimator_text)
         for label in labels:
             self.assertEqual(label.text(), '')
         # 2) The detector combobox ?????? should stay as it is ?????
@@ -732,7 +732,7 @@ class TestEditor(unittest.TestCase):
         self.assertEqual(component.detector_validation_label.text(), '')
 
         # Add a new collimator
-        component.collimator_name_combobox.setCurrentText('3.0mm')
+        component.collimator_name.setText('3.0mm')
         component.x_aperture.setText('3.0')
         component.y_aperture.setText('200.0')
         json_data['instrument'].update(component.value())

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -615,13 +615,15 @@ class TestEditor(unittest.TestCase):
             self.assertEqual(widget.text(), '')
         self.assertEqual(component.collimator_name_combobox.currentText(), '')
         self.assertEqual(component.detector_combobox.currentText(), '')
-        for label in labels:
-            self.assertEqual(label.text(), '')
-        # 2) The component value should be updated to match the input
+        self.assertEqual(component.name_validation_label.text(), '')
+        self.assertEqual(component.aperture_validation_label.text(), '')
+        # 2) But there should be a warning because no detectors are defined
+        self.assertNotEqual(component.detector_validation_label.text(), '')
+        # 3) The component value should be updated to match the input
         self.assertCountEqual(component.value()[component.key], [{}])
-        # 3) The component should not be declared valid -- because required arguments are not provided
+        # 4) The component should not be declared valid -- because required arguments are not provided
         self.assertFalse(component.validate())
-        # 4) The label text should not remain empty -- it should give a warning about the required fields
+        # 5) The label text should not remain empty -- it should give a warning about the required fields
         for label in labels:
             self.assertNotEqual(label.text(), '')
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce(Bug fix, feature, docs update, ...)?** 
Adds UI for creating/editing collimators in the Instrument Editor


* **What is the current behaviour (You can also link to an open issue here)?**
Collimators can only be edited by editing the JSON directly in the Instrument Editor. There are UI components for only the general, instrument jaws and detectors.


* **What is the new behaviour (if this is a feature change)?**
Collimators can be edited using the UI component as well as editing the JSON


* **Does this PR introduce a breaking change (What changes might users need to make in their application due to this PR)?**
No


* **Other information:**
None