### PR TITLE
Deterministic progress bar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 bitarray==2.4.1
-fast-histogram==0.11
 gimpact==0.1.0
 h5py==3.6.0
 jsbeautifier==1.14.6

--- a/sscanss/app/commands/insert.py
+++ b/sscanss/app/commands/insert.py
@@ -5,7 +5,7 @@ import numpy as np
 from PyQt5 import QtWidgets
 from sscanss.core.geometry import (create_tube, create_sphere, create_cylinder, create_cuboid,
                                    closest_triangle_to_point, compute_face_normals, Mesh)
-from sscanss.core.io import read_angles, create_volume_from_tiffs, read_tomoproc_hdf, read_3d_model, BadDataWarning
+from sscanss.core.io import read_angles, read_3d_model, BadDataWarning, load_volume
 from sscanss.core.math import matrix_from_pose, VECTOR_EPS
 from sscanss.core.util import (Primitives, Worker, PointType, LoadVector, MessageType, StrainComponents, CommandID,
                                Attributes)
@@ -151,10 +151,7 @@ class InsertVolumeFromFile(QtWidgets.QUndoCommand):
         """
         with warnings.catch_warnings(record=True) as warning:
             warnings.simplefilter("always")
-            if self.voxel_size is None:
-                self.presenter.model.sample = read_tomoproc_hdf(self.filepath)
-            else:
-                self.presenter.model.sample = create_volume_from_tiffs(self.filepath, self.voxel_size, self.centre)
+            self.presenter.model.sample = load_volume(self.filepath, self.voxel_size, self.centre)
 
             return warning
 

--- a/sscanss/core/io/__init__.py
+++ b/sscanss/core/io/__init__.py
@@ -1,4 +1,4 @@
 from .reader import (read_3d_model, read_obj, read_stl, read_project_hdf, read_points, read_vectors, read_trans_matrix,
-                     read_fpos, validate_vector_length, read_kinematic_calibration_file, read_angles,
+                     read_fpos, validate_vector_length, read_kinematic_calibration_file, read_angles, load_volume,
                      read_robot_world_calibration_file, create_volume_from_tiffs, read_tomoproc_hdf, BadDataWarning)
 from .writer import write_project_hdf, write_binary_stl, write_points, write_volume_as_images, write_fpos

--- a/sscanss/core/io/reader.py
+++ b/sscanss/core/io/reader.py
@@ -8,6 +8,7 @@ import warnings
 import h5py
 import numpy as np
 import psutil
+from scipy.ndimage import zoom
 import tifffile as tiff
 from ..geometry.mesh import Mesh
 from ..geometry.volume import Volume, Curve
@@ -635,15 +636,16 @@ def read_tomoproc_hdf(filename):
 
     :param filename: path of the hdf file
     :type filename: str
-    :return: Volume object containing the data (x, y, z) intensities and the axis positions: x, y, and z
-    :rtype: Volume object
-    :raises: AttributeError
+    :return: 3D array of intensities, size of the volume's voxels and coordinates of the volume centre
+    :rtype: Tuple[np.ndarray[uint8], List[float, float, float], List[float, float, float]]
+    :raises: AttributeError, ValueError, MemoryError
     """
+    report = ProgressReport()
+    report.beginStep('Loading Volume from Nexus File')
 
     with h5py.File(filename, 'r') as hdf_file:
         main_entry = None
         data_folder = None
-        definition = None
 
         for _, item in hdf_file.items():
             if b'NX_class' in item.attrs.keys():
@@ -673,51 +675,82 @@ def read_tomoproc_hdf(filename):
                         break
 
         data = hdf_file[f'{data_folder}/data/data']
+
+        total_iterations = data.shape[0] * 2 if data.dtype == np.float32 else data.shape[0]
         total_required_size = 2 * data.shape[0] * data.shape[1] * data.shape[2]
         if total_required_size >= psutil.virtual_memory().available:
             raise MemoryError('The volume data is larger than the available memory on your machine')
-
-        if data.dtype == np.uint8:
-            volume_data = np.array(data, order='F')
-        elif data.dtype == np.uint16:
-            volume_data = np.zeros(data.shape, np.uint8, order='F')
-            np.multiply(data, 255 / 65535, volume_data, casting='unsafe')
-        elif data.dtype == np.float32:
-            masked_volume = np.ma.array(data, mask=~np.isfinite(data))
-            if masked_volume.mask.all():
-                raise ValueError('Volume data is non-finite i.e. contains only Nans or Inf.')
-            elif masked_volume.mask.any():
-                warnings.warn('Volume data contains non-finite values i.e. Nans or Inf.', BadDataWarning)
-
-            max_value, min_value = masked_volume.max(), masked_volume.min()
-            volume_data = np.zeros(data.shape, np.uint8, order='F')
-            scale_factor = 1 if (max_value - min_value) == 0 else 255 / (max_value - min_value)
-            for i in range(data.shape[0]):
-                volume_slice = data[i]
-                volume_slice[masked_volume.mask[i]] = min_value
-                volume_data[i] = (volume_slice - min_value) * scale_factor
-        else:
-            raise TypeError(f'The files have an unsupported data type: {data.dtype}. The '
-                            f'supported data types are {SUPPORTED_IMAGE_TYPE}')
 
         x = np.array(hdf_file[f'{data_folder}/data/x'])
         y = np.array(hdf_file[f'{data_folder}/data/y'])
         z = np.array(hdf_file[f'{data_folder}/data/z'])
 
-        if not (volume_data.shape == (len(x), len(y), len(z))):
+        if not (data.shape == (len(x), len(y), len(z))):
             raise ValueError('The data arrays in the file are not the same size')
 
         x_spacing = (x[-1] - x[0]) / (len(x) - 1)
         y_spacing = (y[-1] - y[0]) / (len(y) - 1)
         z_spacing = (z[-1] - z[0]) / (len(z) - 1)
-        voxel_size = np.array([x_spacing, y_spacing, z_spacing], np.float32)
+        voxel_size = [x_spacing, y_spacing, z_spacing]
 
         x_origin = x[0] + (x[-1] - x[0]) / 2
         y_origin = y[0] + (y[-1] - y[0]) / 2
         z_origin = z[0] + (z[-1] - z[0]) / 2
-        origin = np.array([x_origin, y_origin, z_origin], np.float32)
+        origin = [x_origin, y_origin, z_origin]
 
-    return Volume(volume_data, voxel_size, origin)
+        rescale_values = []
+        any_non_finite = False
+        volume_data = np.zeros(data.shape, np.uint8, order='F')
+
+        # Slicing in the 3rd dimension is incredibly slow, so we slice 1st dimension instead
+        for i in range(data.shape[0]):
+            if data.dtype == np.uint8:
+                volume_data[i] = data[i]
+            elif data.dtype == np.uint16:
+                volume_data[i] = data[i] / 65535 * 255
+            elif data.dtype == np.float32:
+                image = np.array(data[i])
+                non_finite_values = ~np.isfinite(image)
+                if non_finite_values.any():
+                    any_non_finite = True
+
+                # Scale data between 0 and 254 the use 255 for non-finite values
+                result = np.full(image.shape, 255, dtype=np.uint8)
+                if non_finite_values.all():
+                    rescale_values.append([np.nan, np.nan])
+                else:
+                    valid_values = image[~non_finite_values]
+                    min_value, max_value = valid_values.min(), valid_values.max()
+                    scale_factor = 1 if (max_value - min_value) == 0 else 254 / (max_value - min_value)
+                    result[~non_finite_values] = (valid_values - min_value) * scale_factor
+                    volume_data[i] = result
+                    rescale_values.append([min_value, max_value])
+            else:
+                raise TypeError(f'The files have an unsupported data type: {data.dtype}. The '
+                                f'supported data types are {SUPPORTED_IMAGE_TYPE}')
+            report.updateProgress((i + 1) / total_iterations)
+
+        if rescale_values:
+            # Hack for uniformly rescaling float images one slice at a time to reduce memory
+            rescale_values = np.array(rescale_values).transpose()
+            if np.invert(np.isfinite(rescale_values)).all():
+                raise ValueError(f'Volume slice is non-finite i.e. contains only Nans or Inf. ({filename})')
+            new_min, new_max = np.nanmin(rescale_values[0]), np.nanmax(rescale_values[1])
+            scale_factor = 1 if (new_max - new_min) == 0 else 255 / (new_max - new_min)
+            for i in range(volume_data.shape[0]):
+                non_finite_values = volume_data[i] == 255
+                old_min, old_max = rescale_values[0, i], rescale_values[1, i]
+                if np.isfinite(old_max) and np.isfinite(old_min):
+                    value = volume_data[i] * (old_max - old_min) / 254
+                    volume_data[i] = (value + old_min - new_min) * scale_factor
+                volume_data[i][non_finite_values] = 0
+                report.updateProgress((i + volume_data.shape[0] + 1) / total_iterations)
+
+        if any_non_finite:
+            warnings.warn('Volume data contains non-finite values i.e. Nans or Inf.', BadDataWarning)
+
+    report.completeStep()
+    return volume_data, voxel_size, origin
 
 
 def file_walker(filepath, extension=(".tiff", ".tif")):
@@ -752,27 +785,28 @@ def filename_sorting_key(string, regex=re.compile('(\d+)')):
     return [int(text) if text.isdigit() else text.lower() for text in regex.split(string)]
 
 
-def create_volume_from_tiffs(filepath, voxel_size, centre):
+def create_volume_from_tiffs(file_path):
     """Creates from a volume from tiff files and creates volume
 
-    :param filepath: path of the folder containing TIFF files
-    :type filepath: str
-    :param voxel_size: size of the volume's voxels in the x, y, and z axes
-    :type voxel_size: List[float, float, float]
-    :param centre: coordinates of the volume centre in the x, y, and z axes
-    :type centre: List[float, float, float]
-    :return: volume object
-    :rtype: Volume
+    :param file_path: path of the folder containing TIFF files
+    :type file_path: str
+    :return: array of images
+    :rtype: np.array
     :raises: ValueError, MemoryError
     """
     report = ProgressReport()
-    tiff_names = file_walker(filepath)
+    report.beginStep('Loading Volume from Tiff Images')
+
+    tiff_names = file_walker(file_path)
 
     if not tiff_names:
         raise ValueError('There are no valid ".tiff" files in this folder')
 
     first_image = tiff.imread(tiff_names[0])
+    image_type = first_image.dtype
     y_size, x_size = np.shape(first_image)
+
+    total_iterations = len(tiff_names) * 2 if image_type == np.float32 else len(tiff_names)
 
     total_required_size = 2 * x_size * y_size * len(tiff_names)
     if total_required_size >= psutil.virtual_memory().available:
@@ -784,11 +818,11 @@ def create_volume_from_tiffs(filepath, voxel_size, centre):
     any_non_finite = False
     for i, filename in enumerate(sorted(tiff_names, key=filename_sorting_key)):
         loaded_tiff = tiff.imread(filename).transpose()
-        if loaded_tiff.dtype == np.uint8:
+        if image_type == np.uint8:
             stack_of_tiffs[:, :, i] = loaded_tiff
-        elif loaded_tiff.dtype == np.uint16:
+        elif image_type == np.uint16:
             stack_of_tiffs[:, :, i] = loaded_tiff * 255.0 / 65535.0
-        elif loaded_tiff.dtype == np.float32:
+        elif image_type == np.float32:
             non_finite_values = ~np.isfinite(loaded_tiff)
             if non_finite_values.all():
                 raise ValueError(f'Volume slice is non-finite i.e. contains only Nans or Inf. ({filename})')
@@ -804,9 +838,10 @@ def create_volume_from_tiffs(filepath, voxel_size, centre):
             stack_of_tiffs[:, :, i] = result
             rescale_values.append([min_value, max_value])
         else:
-            raise TypeError(f'The files have an unsupported data type: {first_image.dtype}. The '
+            raise TypeError(f'The files have an unsupported data type: {image_type}. The '
                             f'supported data types are {SUPPORTED_IMAGE_TYPE}')
-        report.updateProgress((i + 1) / len(tiff_names))
+
+        report.updateProgress((i + 1) / total_iterations)
 
     if any_non_finite:
         warnings.warn('Volume data contains non-finite values i.e. Nans or Inf.', BadDataWarning)
@@ -821,5 +856,68 @@ def create_volume_from_tiffs(filepath, voxel_size, centre):
             value = stack_of_tiffs[:, :, i] * (old_max - old_min) / 254
             stack_of_tiffs[:, :, i] = (value + old_min - new_min) * scale_factor
             stack_of_tiffs[:, :, i][non_finite_values] = 0
+            report.updateProgress((i + len(tiff_names) + 1) / total_iterations)
 
-    return Volume(stack_of_tiffs, np.array(voxel_size, np.float32), np.array(centre, np.float32))
+    report.completeStep()
+    return stack_of_tiffs
+
+
+def load_volume(file_path, voxel_size=None, centre=None, max_bytes=2e9, max_dim=1024):
+    """Loads volume from TIFFs or a nexus file. The data is binned if larger than the max_bytes so that its
+    max dimension is max_dim
+
+    :param file_path: file path of volume (folder for tiffs or file path for nexus)
+    :type file_path: str
+    :param voxel_size: size of the volume's voxels in the x, y, and z axes
+    :type voxel_size: Optional(List[float, float, float])
+    :param centre: coordinates of the volume centre in the x, y, and z axes
+    :type centre: Optional(List[float, float, float])
+    :param max_bytes: maximum number of bytes before binning
+    :type max_bytes: int
+    :param max_dim: maximum dimension of binned data
+    :type max_dim: int
+    :return: volume object
+    :rtype: Volume
+    """
+    report = ProgressReport()
+    report.start('Loading Volume from File', 3)
+    if voxel_size is None:
+        images, voxel_size, centre = read_tomoproc_hdf(file_path)
+    else:
+        images = create_volume_from_tiffs(file_path)
+
+    report.nextStep()
+
+    if images.nbytes > max_bytes:
+        image_count = images.shape[2]
+        scale = max_dim / np.max(images.shape)
+        new_shape = tuple([int(round(dim * scale)) for dim in images.shape])
+        binned_data = np.zeros(new_shape, dtype=np.uint8, order='F')
+        tmp_target = np.zeros((*new_shape[:2], image_count), dtype=np.uint8, order='F')
+
+        total_iterations = tmp_target.shape[1] + image_count
+        for i in range(image_count):
+            tmp_target[:, :, i] = zoom(images[:, :, i], scale, order=0)
+            report.updateProgress((i + 1) / total_iterations)
+
+        for i in range(tmp_target.shape[1]):
+            binned_data[:, i, :] = zoom(tmp_target[:, i, :], (1, scale), order=0)
+            report.updateProgress((i + image_count + 1) / total_iterations)
+    else:
+        binned_data = images
+
+    report.nextStep()
+    count = binned_data.shape[2]
+    hist_per_image = np.zeros((count, 256), dtype=np.int32)
+    for i in range(count):
+        hist_per_image[i, :] = np.bincount(binned_data[:, :, i].ravel(), minlength=256)
+        report.updateProgress((i + 1) / count)
+    histogram = (np.sum(hist_per_image, axis=0), np.linspace(0, 255, 257))
+
+    volume = Volume(images,
+                    np.array(voxel_size, np.float32),
+                    np.array(centre, np.float32),
+                    histogram,
+                    binned_data=binned_data)
+    report.complete()
+    return volume

--- a/sscanss/core/io/writer.py
+++ b/sscanss/core/io/writer.py
@@ -257,8 +257,11 @@ def write_volume_as_images(folder_path, volume):
     :type volume: Volume
     """
     report = ProgressReport()
-    for i in range(volume.data.shape[2]):
-        filename = os.path.join(folder_path, f'{i + 1:0>{len(str(volume.data.shape[2]))}}.tiff')
+    report.beginStep('Exporting Volume as TIFF Images')
+    image_count = volume.data.shape[2]
+    for i in range(image_count):
+        filename = os.path.join(folder_path, f'{i + 1:0>{len(str(image_count))}}.tiff')
         image = volume.data[:, :, i].transpose()
         tiff.imsave(filename, image)
-        report.updateProgress((i + 1) / volume.data.shape[2])
+        report.updateProgress((i + 1) / image_count)
+    report.completeStep()

--- a/sscanss/core/io/writer.py
+++ b/sscanss/core/io/writer.py
@@ -9,6 +9,7 @@ import numpy as np
 import tifffile as tiff
 from ..geometry.mesh import Mesh
 from ..geometry.volume import Volume
+from ..util.worker import ProgressReport
 from ...config import __version__, settings
 
 
@@ -255,7 +256,9 @@ def write_volume_as_images(folder_path, volume):
     :param volume: volume
     :type volume: Volume
     """
+    report = ProgressReport()
     for i in range(volume.data.shape[2]):
         filename = os.path.join(folder_path, f'{i + 1:0>{len(str(volume.data.shape[2]))}}.tiff')
         image = volume.data[:, :, i].transpose()
         tiff.imsave(filename, image)
+        report.updateProgress((i + 1) / volume.data.shape[2])

--- a/sscanss/core/util/__init__.py
+++ b/sscanss/core/util/__init__.py
@@ -1,7 +1,7 @@
 from .misc import (Directions, Primitives, to_float, TransformType, DockFlag, PointType, Attributes, POINT_DTYPE,
                    StrainComponents, LoadVector, MessageType, CommandID, toggle_action_in_group, PlaneOptions,
                    compact_path, find_duplicates, MessageReplyType, InsertSampleOptions, Anchor)
-from .worker import Worker
+from .worker import Worker, ProgressReport
 from .forms import FormGroup, FormControl, CompareValidator, Banner, FormTitle
 from .widgets import (create_icon, create_header, create_scroll_area, create_tool_button, FileDialog, FilePicker,
                       Accordion, Pane, StatusBar, ColourPicker, StyledTabWidget)

--- a/static/style.css
+++ b/static/style.css
@@ -124,6 +124,7 @@ QProgressBar {
 
 QProgressBar::chunk {
     background-color: DodgerBlue;
+    width: 1px
 }
 
 PickPointDialog QSplitter::handle {

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -463,7 +463,7 @@ class TestVolumeClass(unittest.TestCase):
 
         transform[:3, 3] = [1, 0.25, 0]
         data = np.full((5, 4, 3), [0, 127, 255], np.float32).transpose()
-        volume = Volume(data, np.array([1, 0.5, 2]), np.array([1, 0.25, 0]), max_bytes=10, max_dim=4)
+        volume = Volume(data, np.array([1, 0.5, 2]), np.array([1, 0.25, 0]), binned_data=np.zeros((2, 3, 4)))
         self.assertEqual(volume.shape, (3, 4, 5))
         self.assertNotEqual(volume.curve.inputs[0], volume.curve.inputs[1])
         np.testing.assert_array_almost_equal(volume.data, data, decimal=5)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -18,7 +18,7 @@ from sscanss.core.util import (StatusBar, ColourPicker, FileDialog, FilePicker, 
 from sscanss.app.dialogs import (SimulationDialog, ScriptExportDialog, PathLengthPlotter, PointManager, VectorManager,
                                  DetectorControl, JawControl, PositionerControl, TransformDialog, AlignmentErrorDialog,
                                  CalibrationErrorDialog, VolumeLoader, InstrumentCoordinatesDialog, CurveEditor,
-                                 SampleProperties)
+                                 SampleProperties, ProgressDialog)
 from sscanss.app.widgets import PointModel, AlignmentErrorModel, ErrorDetailModel
 from sscanss.app.window.presenter import MainWindowPresenter
 from sscanss.app.window.view import Updater
@@ -2176,6 +2176,35 @@ class TestSamplePropertiesDialog(unittest.TestCase):
     def testNoneSamplePropertiesDialog(self):
         self.assertEqual('Memory (MB)', self.dialog.sample_property_table.item(0, 0).text())
         self.assertEqual('0', self.dialog.sample_property_table.item(0, 1).text())
+
+
+class TestProgressDialog(unittest.TestCase):
+    @mock.patch("sscanss.app.dialogs.misc.ProgressReport", autospec=True)
+    def setUp(self, report_mock):
+        self.view = TestView()
+        report_mock.return_value.progress_updated = TestSignal()
+        report_mock.return_value.message = 'Determinate'
+        self.report_mock = report_mock
+        self.dialog = ProgressDialog(self.view)
+        self.dialog.show = mock.Mock()
+
+    def testProgress(self):
+        self.dialog.show.assert_not_called()
+        self.dialog.showMessage('Indeterminate')
+        self.dialog.show.assert_called()
+        self.assertEqual(self.dialog.message.text(), 'Indeterminate')
+        self.assertFalse(self.dialog.determinate)
+        self.assertEqual(self.dialog.percent_label.text(), '')
+        self.report_mock.return_value.progress_updated.emit(0.5)
+        self.assertTrue(self.dialog.determinate)
+        self.assertEqual(self.dialog.percent_label.text(), '50%')
+        self.assertEqual(self.dialog.message.text(), 'Determinate')
+        self.report_mock.return_value.progress_updated.emit(0.75)
+        self.assertEqual(self.dialog.percent_label.text(), '75%')
+        self.assertEqual(self.dialog.progress_bar.value(), 75)
+        self.dialog.setProgress(1.0)
+        self.assertEqual(self.dialog.percent_label.text(), '100%')
+        self.assertEqual(self.dialog.progress_bar.value(), 100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce(Bug fix, feature, docs update, ...)?** 
This creates a deterministic progress bar for operations that load or write volume data (closes #51) 


* **What is the current behaviour (You can also link to an open issue here)?**
The progress bar is non-deterministic

* **What is the new behaviour (if this is a feature change)?**

1. Load a volume sample from tiff or nexus file (**Insert > Volume**) and the progress bar should show operation progress from 0 to 100%
2. Write a volume (**File > Export > Sample**) and the progress bar should also show operation progress from 0 to 100%

* **Does this PR introduce a breaking change (What changes might users need to make in their application due to this PR)?**
No


* **Other information:**
![Screenshot 2022-11-04 163704](https://user-images.githubusercontent.com/34302892/200028607-32cfea0c-5cb2-4926-842a-933296595c89.png)
