### PR TITLE
Adds a cone primitive 

### DIFF
--- a/docs/add_sample.rst
+++ b/docs/add_sample.rst
@@ -17,7 +17,7 @@ The 3D model for a Sample may be imported from ASCII/binary STL files or Wavefro
 ******************************
 Create a model from primitives
 ******************************
-Simple models may be generated from primitives, e.g. cuboids, spheres, tubes, etc. Click
+Simple models may be generated from primitives, e.g. cuboids, spheres, tubes, cone etc. Click
 **Insert > Sample > primitives** and select the desired primitive. Type in the required parameters for defining
 the primitive and click the **Create** button.
 

--- a/sscanss/app/commands/insert.py
+++ b/sscanss/app/commands/insert.py
@@ -3,7 +3,7 @@ import os
 import warnings
 import numpy as np
 from PyQt5 import QtWidgets
-from sscanss.core.geometry import (create_tube, create_sphere, create_cylinder, create_cuboid,
+from sscanss.core.geometry import (create_tube, create_sphere, create_cylinder, create_cuboid, create_cone,
                                    closest_triangle_to_point, compute_face_normals, Mesh)
 from sscanss.core.io import read_angles, create_volume_from_tiffs, read_tomoproc_hdf, read_3d_model, BadDataWarning
 from sscanss.core.math import matrix_from_pose, VECTOR_EPS
@@ -44,8 +44,10 @@ class InsertPrimitive(QtWidgets.QUndoCommand):
             mesh = create_sphere(**self.args)
         elif self.primitive == Primitives.Cylinder:
             mesh = create_cylinder(**self.args)
-        else:
+        elif self.primitive == Primitives.Cuboid:
             mesh = create_cuboid(**self.args)
+        else:
+            mesh = create_cone(**self.args)
 
         self.presenter.model.addMeshToProject(mesh, self.option)
 

--- a/sscanss/app/dialogs/insert.py
+++ b/sscanss/app/dialogs/insert.py
@@ -35,8 +35,10 @@ class InsertPrimitiveDialog(QtWidgets.QWidget):
             self.mesh_args = {'radius': 100.000}
         elif self.primitive == Primitives.Cylinder:
             self.mesh_args = {'radius': 100.000, 'height': 200.000}
-        else:
+        elif self.primitive == Primitives.Cuboid:
             self.mesh_args = {'width': 50.000, 'height': 100.000, 'depth': 200.000}
+        else:
+            self.mesh_args = {'radius': 100.000, 'height': 200.000}
 
         self.createPrimitiveSwitcher()
         self.createFormInputs()

--- a/sscanss/core/geometry/__init__.py
+++ b/sscanss/core/geometry/__init__.py
@@ -1,4 +1,4 @@
-from .primitive import create_cuboid, create_cylinder, create_sphere, create_tube, create_plane
+from .primitive import create_cuboid, create_cylinder, create_sphere, create_tube, create_plane, create_cone
 from .intersection import (closest_triangle_to_point, mesh_plane_intersection, segment_triangle_intersection,
                            segment_plane_intersection, path_length_calculation, point_selection,
                            volume_plane_intersection, volume_ray_intersection)

--- a/sscanss/core/geometry/primitive.py
+++ b/sscanss/core/geometry/primitive.py
@@ -6,7 +6,7 @@ from .mesh import Mesh
 from ..math.transform import rotation_btw_vectors
 
 
-def create_cone(radius=1.0, height=1.0, slices=4, stacks=1, closed=True):
+def create_cone(radius=1.0, height=1.0, slices=64, stacks=1, closed=True):
     """Generates the vertices, normals, and indices for a cone mesh
 
     :param radius: cone base radius

--- a/sscanss/core/geometry/primitive.py
+++ b/sscanss/core/geometry/primitive.py
@@ -32,15 +32,15 @@ def create_cone(radius=1.0, height=1.0, slices=64, stacks=1, closed=True):
 
     y = np.tile(np.cos(theta), stacks + 1) * r
 
-    z_div = np.linspace(0.0, 1.0, stacks + 1)
+    z_div = np.linspace(-0.5, 0.5, stacks + 1)
     z = np.repeat(z_div * height, slices)
 
     vertices = np.column_stack((x, y, z))
 
-    lenght = np.sqrt(height**2 + radius**2)
-    n_x = radius * np.sin(theta) / lenght
-    n_y = radius * np.cos(theta) / lenght
-    n_z = np.repeat(height / lenght, slices)
+    length = np.sqrt(height**2 + radius**2)
+    n_x = radius * np.sin(theta) / length
+    n_y = radius * np.cos(theta) / length
+    n_z = np.repeat(height / length, slices)
     normals = np.tile(np.column_stack((n_x, n_y, n_z)), (stacks + 1, 1))
 
     a = np.fromiter((i for i in range(slices * stacks)), int)
@@ -51,12 +51,13 @@ def create_cone(radius=1.0, height=1.0, slices=64, stacks=1, closed=True):
 
     # Add the base
     if closed:
+        half_height = height / 2
         x = radius * np.sin(theta)
         y = radius * np.cos(theta)
-        z = np.full(slices, [0])
+        z = np.full(slices, [-half_height])
 
         base_perimeter_vertices = np.column_stack((x, y, z))
-        base_vertices = np.vstack((np.zeros((1, 3)), base_perimeter_vertices))
+        base_vertices = np.vstack(((0, 0, -half_height), base_perimeter_vertices))
 
         bottom_row = len(base_vertices) - slices
         a = bottom_row + np.arange(slices) + len(vertices)

--- a/sscanss/core/geometry/primitive.py
+++ b/sscanss/core/geometry/primitive.py
@@ -15,6 +15,10 @@ def create_cone(radius=1.0, height=1.0, slices=64, stacks=1, closed=True):
     :type height: float
     :param slices: number of radial segments to use
     :type slices: int
+    :param stacks: number of height segments to use
+    :type stacks: int
+    :param closed: indicates if mesh should be closed at the bottom
+    :type closed: bool
     :return: The vertices, normals and index array of the mesh
     :rtype: Mesh
     """
@@ -22,23 +26,21 @@ def create_cone(radius=1.0, height=1.0, slices=64, stacks=1, closed=True):
     theta = np.linspace(0, 2 * np.pi, slices + 1)[:-1]
 
     # Add the cone
-    r = np.repeat(np.linspace(1.0, 0.0, stacks + 1), slices)
+    r = np.repeat(np.linspace(1.0, 0.0, stacks + 1), slices) * radius
 
-    x = np.tile(np.sin(theta), stacks + 1)
-    scaled_x = np.multiply(x, r)
+    x = np.tile(np.sin(theta), stacks + 1) * r
 
-    y = np.tile(np.cos(theta), stacks + 1)
-    scaled_y = np.multiply(y, r)
+    y = np.tile(np.cos(theta), stacks + 1) * r
 
     z_div = np.linspace(0.0, 1.0, stacks + 1)
     z = np.repeat(z_div * height, slices)
 
-    vertices = np.column_stack((radius * scaled_x, radius * scaled_y, z))
+    vertices = np.column_stack((x, y, z))
 
-    l = np.sqrt(height**2 + radius**2)
-    n_x = radius * np.sin(theta) / l
-    n_y = radius * np.cos(theta) / l
-    n_z = np.repeat(height / l, slices)
+    lenght = np.sqrt(height**2 + radius**2)
+    n_x = radius * np.sin(theta) / lenght
+    n_y = radius * np.cos(theta) / lenght
+    n_z = np.repeat(height / lenght, slices)
     normals = np.tile(np.column_stack((n_x, n_y, n_z)), (stacks + 1, 1))
 
     a = np.fromiter((i for i in range(slices * stacks)), int)

--- a/sscanss/core/geometry/primitive.py
+++ b/sscanss/core/geometry/primitive.py
@@ -20,8 +20,6 @@ def create_cone(radius=1.0, height=1.0, slices=64, stacks=1, closed=True):
     """
 
     theta = np.linspace(0, 2 * np.pi, slices + 1)[:-1]
-    angle_step = 2 * np.pi / slices
-    angle = theta + (angle_step / 2)
 
     # Add the cone
     r = np.repeat(np.linspace(1.0, 0.0, stacks + 1), slices)
@@ -38,10 +36,10 @@ def create_cone(radius=1.0, height=1.0, slices=64, stacks=1, closed=True):
     vertices = np.column_stack((radius * scaled_x, radius * scaled_y, z))
 
     l = np.sqrt(height**2 + radius**2)
-    n_x = height * np.sin(angle) / l
-    n_y = height * np.cos(angle) / l
-    n_z = np.repeat(radius / l, slices)
-    normals = np.column_stack((n_x, n_y, n_z))
+    n_x = radius * np.sin(theta) / l
+    n_y = radius * np.cos(theta) / l
+    n_z = np.repeat(height / l, slices)
+    normals = np.tile(np.column_stack((n_x, n_y, n_z)), (stacks + 1, 1))
 
     a = np.fromiter((i for i in range(slices * stacks)), int)
     b = slices + a

--- a/sscanss/core/util/misc.py
+++ b/sscanss/core/util/misc.py
@@ -40,6 +40,7 @@ class TransformType(Enum):
 @unique
 class Primitives(Enum):
     """Types of primitive"""
+    Cone = 'Cone'
     Cuboid = 'Cuboid'
     Cylinder = 'Cylinder'
     Sphere = 'Sphere'

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -76,6 +76,7 @@ class TestView(QMainWindow):
         self.showMessage = do_nothing
         self.showPathLength = do_nothing
         self.showScriptExport = do_nothing
+        self.primitives_menu = None
 
 
 def click_message_box(button_text):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -291,6 +291,13 @@ class TestInsertCommands(unittest.TestCase):
         cmd.redo()
         self.model_mock.return_value.addMeshToProject.assert_called_once()
 
+        # Command to add a cone to sample
+        self.model_mock.reset_mock()
+        args = {"radius": 100.000, "height": 200.000}
+        cmd = InsertPrimitive(Primitives.Cone, args, self.presenter, InsertSampleOptions.Combine)
+        cmd.redo()
+        self.model_mock.return_value.addMeshToProject.assert_called_once()
+
         # Command to add a sphere to sample
         self.model_mock.reset_mock()
         args = {"radius": 100.000}

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2289,21 +2289,14 @@ class TestInsertPrimitiveDialog(unittest.TestCase):
                                                                     test_case['mesh_args_custom'])
 
                 # Testing with zero and negative values
-                if test_case['parameter_count'] >= 2:
-                    control_first = self.dialog.form_group.form_controls[0]
-                    control_second = self.dialog.form_group.form_controls[1]
-
-                    control_first.value = 0
-                    control_second.value = 10
+                for ix in range(test_case['parameter_count']):
+                    control = self.dialog.form_group.form_controls[ix]
+                    value = control.value
+                    control.value = 0
                     self.assertFalse(self.dialog.create_primitive_button.isEnabled())
-
-                    control_first.value = 10
-                    control_second.value = 0
+                    control.value = -50
                     self.assertFalse(self.dialog.create_primitive_button.isEnabled())
-
-                    control_first.value = -50
-                    control_second.value = -50
-                    self.assertFalse(self.dialog.create_primitive_button.isEnabled())
+                    control.value = value
 
                 # Testing with inner radius greater than outer radius for tube
                 if test_case['primitive'] == Primitives.Tube:

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,3 +1,7 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath('..'))
 import unittest
 import unittest.mock as mock
 from urllib.error import URLError, HTTPError
@@ -2285,11 +2289,20 @@ class TestInsertPrimitiveDialog(unittest.TestCase):
                                                                     test_case['mesh_args_custom'])
 
                 # Testing with zero and negative values
-                for ix in range(test_case['parameter_count']):
-                    control = self.dialog.form_group.form_controls[ix]
-                    control.value = 0
+                if test_case['parameter_count'] >= 2:
+                    control_first = self.dialog.form_group.form_controls[0]
+                    control_second = self.dialog.form_group.form_controls[1]
+
+                    control_first.value = 0
+                    control_second.value = 10
                     self.assertFalse(self.dialog.create_primitive_button.isEnabled())
-                    control.value = -50
+
+                    control_first.value = 10
+                    control_second.value = 0
+                    self.assertFalse(self.dialog.create_primitive_button.isEnabled())
+
+                    control_first.value = -50
+                    control_second.value = -50
                     self.assertFalse(self.dialog.create_primitive_button.isEnabled())
 
                 # Testing with inner radius greater than outer radius for tube

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,7 +1,3 @@
-import sys
-import os
-
-sys.path.append(os.path.abspath('..'))
 import unittest
 import unittest.mock as mock
 from urllib.error import URLError, HTTPError

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2191,8 +2191,8 @@ class TestInsertPrimitiveDialog(unittest.TestCase):
         self.model_mock.return_value.instruments = [dummy]
         self.model_mock.return_value.sample_changed = TestSignal()
         self.model_mock.return_value.sample = None
-        self.presenter.addPrimitive = mock.Mock()
         self.presenter = MainWindowPresenter(self.view)
+        self.presenter.addPrimitive = mock.Mock()
         self.view.scenes = mock.create_autospec(SceneManager)
         self.view.presenter = self.presenter
 


### PR DESCRIPTION
Closes #96 

- [x] Added an option for a Cone primitive with default radius 100 mm and default height 200 mm accessible via the menu Insert > Sample> Primitives > Cone
- [x] Updated the docs 
- [x] Updated the InsertPrimitiveCommand tests
- [x] Added the InsertPrimitiveDialog tests in test_widgets.py
