### PR TITLE
Fixes incorrect CFLAGS which breaks the Linux installer

### DIFF
--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -126,6 +126,8 @@ echo ""
 echo "Building executable (This should take a few minutes) ..."
 
 python_exec="./envs/sscanss/bin/python"
+CFLAGS=$(./envs/sscanss/bin/python3-config --includes)
+export CFLAGS=$CFLAGS
 $python_exec -m pip install --no-cache-dir --no-index --no-build-isolation --find-links packages -r "./sscanss/requirements.txt" &>/dev/null
 if [ "$INSTALL_EDITOR" = y ]; then
     $python_exec "./sscanss/make.py" --build-sscanss --build-editor &>/dev/null

--- a/make.py
+++ b/make.py
@@ -25,7 +25,7 @@ EXCLUDED_IMPORT = [
     'PyQt5.QtSvg', '--exclude-module', 'PyQt5.QtSerialPort', '--exclude-module', 'PyQt5.QtNetwork', '--exclude-module',
     'PyQt5.QtScript', '--exclude-module', 'PyQt5.QtXml', '--exclude-module', 'PyQt5.QtXmlPatterns'
 ]
-HIDDEN_IMPORT = ['--hidden-import', 'pkg_resources.py2_warn']
+HIDDEN_IMPORT = ['--hidden-import', 'pkg_resources.py2_warn', '--hidden-import', 'OpenGL.platform.egl']
 IS_WINDOWS = sys.platform.startswith('win')
 IS_MAC = True if sys.platform == 'darwin' else False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ jsonschema==4.4.0
 matplotlib==3.4.3
 NLopt==2.7.0
 numpy==1.21.6
+Pillow==9.0.0
 PyInstaller==4.10
 PyOpenGL==3.1.6
 PyQt5==5.15.6

--- a/sscanss/config.py
+++ b/sscanss/config.py
@@ -4,12 +4,16 @@ import json
 import logging
 import logging.config
 from multiprocessing import Manager
+import os
 import pathlib
 import sys
 import platform
 from OpenGL.plugins import FormatHandler
 from PyQt5 import QtCore, QtWidgets
 from sscanss.__version import __version__
+
+if os.environ.get('XDG_SESSION_TYPE') == 'wayland':
+    os.environ['QT_QPA_PLATFORM'] = 'wayland-egl'
 
 if getattr(sys, "frozen", False):
     # we are running in a bundle


### PR DESCRIPTION
Latest setuptools uses the wrong include directory in the CFLAGS when installing the packages for the Linux installer. So the installer fails because _Pyhton.h is not found_.

This fixes the issue by adding the correct include directory via environment variable

