### PR TITLE
Font dialog for editor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [windows-latest]
+        platform: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [windows-latest, ubuntu-latest, macos-latest]
+        platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/docs/editor.rst
+++ b/docs/editor.rst
@@ -28,7 +28,8 @@ There are five menus on the menu bar:
 Menu                    Description
 ==================      =============================================
 File                    Create new, open and save instrument
-                        description JSON file.
+                        description JSON file. Access and update 
+                        preferences such as editor font.
 Edit                    Search for text within the editor json file.    
 View                    Change camera view in the graphics window,
                         open instrument control, rest instrument and

--- a/sscanss/config.py
+++ b/sscanss/config.py
@@ -91,6 +91,8 @@ class Key(Enum):
     Check_Update = 'Check_Update'
     Recent_Projects = 'Recent_Projects'
     Recent_Editor_Projects = 'Recent_Editor_Projects'
+    Editor_Font_Family = f'{Group.General.value}/Editor_Font_Family'
+    Editor_Font_Size = f'{Group.General.value}/Editor_Font_Size'
     Align_First = f'{Group.Simulation.value}/Align_First'
     Position_Stop_Val = f'{Group.Simulation.value}/Position_Stop_Val'
     Angular_Stop_Val = f'{Group.Simulation.value}/Angular_Stop_Val'
@@ -142,6 +144,8 @@ __defaults__ = {
     Key.Align_First: SettingItem(True),
     Key.Recent_Projects: SettingItem([], sub_type=str),
     Key.Recent_Editor_Projects: SettingItem([], sub_type=str),
+    Key.Editor_Font_Family: SettingItem('Courier'),
+    Key.Editor_Font_Size: SettingItem(10),
     Key.Local_Max_Eval: SettingItem(1000, limits=(500, 5000)),
     Key.Global_Max_Eval: SettingItem(200, limits=(50, 500)),
     Key.Angular_Stop_Val: SettingItem(1.00, limits=(0.000, 360.000)),

--- a/sscanss/editor/dialogs.py
+++ b/sscanss/editor/dialogs.py
@@ -545,7 +545,7 @@ class FontWidget(QtWidgets.QDialog):
         self.selectors.addWidget(self.size_combobox)
 
         self.preview = QtWidgets.QLabel("Preview")
-        self.preview.setFont(QtGui.QFont(current_family, current_size))
+        self.preview.setStyleSheet(f"font: {current_size}pt {current_family}")
         self.selectors.addWidget(self.preview)
 
         self.family_combobox.currentFontChanged.connect(self.updatePreviewFont)
@@ -561,6 +561,6 @@ class FontWidget(QtWidgets.QDialog):
 
     def updatePreviewFont(self):
         """Updates the preview text font based on the currently selected font family and font size"""
-        selected_font = self.family_combobox.currentFont()
+        selected_family = self.family_combobox.currentFont().family()
         selected_size = int(self.size_combobox.currentText())
-        self.preview.setFont(QtGui.QFont(selected_font.family(), selected_size))
+        self.preview.setStyleSheet(f"font: {selected_size}pt {selected_family}")

--- a/sscanss/editor/dialogs.py
+++ b/sscanss/editor/dialogs.py
@@ -527,13 +527,14 @@ class FontWidget(QtWidgets.QDialog):
 
         self.setWindowTitle('Fonts')
 
+        self.selectors = QtWidgets.QVBoxLayout()
+
         current_family = settings.value(settings.Key.Editor_Font_Family)
         current_size = settings.value(settings.Key.Editor_Font_Size)
 
-        self.selectors = QtWidgets.QVBoxLayout()
-
         self.selectors.addWidget(QtWidgets.QLabel('Font family'))
         self.family_combobox = QtWidgets.QFontComboBox()
+        self.family_combobox.setCurrentFont(QtGui.QFont(current_family,9))
         self.selectors.addWidget(self.family_combobox)
 
         self.selectors.addWidget(QtWidgets.QLabel('Font size'))

--- a/sscanss/editor/dialogs.py
+++ b/sscanss/editor/dialogs.py
@@ -510,3 +510,40 @@ class FindWidget(QtWidgets.QDialog):
         """Resets the FindWidget window"""
         self.fist_search_flag = True
         self.status_box.setText("")
+
+class UpdateFontWidget(QtWidgets.QDialog):
+    """Creates a widget that displays combo boxes for font family and size.
+        :param parent: main window instance
+        :type parent: MainWindow
+        """
+
+    size_step = 2
+    min_size = 2
+    max_size = 32
+
+    def __init__(self, parent):
+        super().__init__(parent)
+
+        self.setWindowTitle('Fonts')
+
+        self.selectors = QtWidgets.QVBoxLayout()
+        self.family_selector()
+        self.size_selector()
+        self.setLayout(self.selectors)
+
+    def family_selector(self):
+        """Adds a widget to the dialog to enable selection of font family from a combobox"""
+        family_label = QtWidgets.QLabel()
+        family_label.setText('Font Family')
+        self.selectors.addWidget(family_label)
+        self.selectors.addWidget(QtWidgets.QFontComboBox())
+    
+    def size_selector(self):
+        """Adds a widget to the dialog to enable selection of font size from a combobox"""
+        size_label = QtWidgets.QLabel()
+        size_label.setText('Font Size')
+        self.selectors.addWidget(size_label)
+        size_combobox = QtWidgets.QComboBox()
+        size_combobox.setEditable(True)
+        size_combobox.addItems([str(n) for n in range(self.min_size,self.max_size+2,self.size_step)])
+        self.selectors.addWidget(size_combobox)

--- a/sscanss/editor/dialogs.py
+++ b/sscanss/editor/dialogs.py
@@ -551,11 +551,11 @@ class FontWidget(QtWidgets.QDialog):
         self.family_combobox.currentFontChanged.connect(self.updatePreviewFont)
         self.size_combobox.currentTextChanged.connect(self.updatePreviewFont)
 
-        buttons = QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel
-        self.buttonBox = QtWidgets.QDialogButtonBox(buttons)
-        self.buttonBox.accepted.connect(self.accept)
-        self.buttonBox.rejected.connect(self.reject)
-        self.selectors.addWidget(self.buttonBox)
+        self.button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.StandardButton.Ok
+                                                     | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        self.selectors.addWidget(self.button_box)
 
         self.setLayout(self.selectors)
 

--- a/sscanss/editor/dialogs.py
+++ b/sscanss/editor/dialogs.py
@@ -512,6 +512,7 @@ class FindWidget(QtWidgets.QDialog):
         self.fist_search_flag = True
         self.status_box.setText("")
 
+
 class FontWidget(QtWidgets.QDialog):
     """Creates a widget that displays combo boxes for font family and size.
         :param parent: main window instance
@@ -534,17 +535,17 @@ class FontWidget(QtWidgets.QDialog):
 
         self.selectors.addWidget(QtWidgets.QLabel('Font family'))
         self.family_combobox = QtWidgets.QFontComboBox()
-        self.family_combobox.setCurrentFont(QtGui.QFont(current_family,9))
+        self.family_combobox.setCurrentFont(QtGui.QFont(current_family, 9))
         self.selectors.addWidget(self.family_combobox)
 
         self.selectors.addWidget(QtWidgets.QLabel('Font size'))
         self.size_combobox = QtWidgets.QComboBox()
-        self.size_combobox.addItems([str(n) for n in range(self.min_size,self.max_size+2,self.size_step)])
+        self.size_combobox.addItems([str(n) for n in range(self.min_size, self.max_size + 2, self.size_step)])
         self.size_combobox.setCurrentText(str(current_size))
         self.selectors.addWidget(self.size_combobox)
 
         self.preview = QtWidgets.QLabel("Preview")
-        self.preview.setFont(QtGui.QFont(current_family,current_size))
+        self.preview.setFont(QtGui.QFont(current_family, current_size))
         self.selectors.addWidget(self.preview)
 
         self.family_combobox.currentFontChanged.connect(self.updatePreviewFont)
@@ -562,5 +563,4 @@ class FontWidget(QtWidgets.QDialog):
         """Updates the preview text font based on the currently selected font family and font size"""
         selected_font = self.family_combobox.currentFont()
         selected_size = int(self.size_combobox.currentText())
-        self.preview.setFont(QtGui.QFont(selected_font.family(),selected_size))
-
+        self.preview.setFont(QtGui.QFont(selected_font.family(), selected_size))

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -15,9 +15,9 @@ class Editor(QsciScintilla):
 
         super().__init__(parent)
 
-        self.updateStyle(parent.editor_font_family,parent.editor_font_size)
+        self.updateStyle(parent.editor_font_family, parent.editor_font_size)
 
-    def updateStyle(self,font_family,font_size):
+    def updateStyle(self, font_family, font_size):
         """Updates the editor style. 
             :param font_family: font family as string
             :type font_family: str

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -16,25 +16,19 @@ class Editor(QsciScintilla):
 
         super().__init__(parent)
 
-        font_family = settings.value(settings.Key.Editor_Font_Family)
-        font_size = settings.value(settings.Key.Editor_Font_Size)
+        self.updateStyle(parent.editor_font_family,parent.editor_font_size)
 
-        self.updateStyle(font_family,font_size)
-
-    def updateStyle(self,family,size):
+    def updateStyle(self,font_family,font_size):
         """Updates the editor style. Caches currently selected font family and font size to the global settings.
-            :param family: font family as string
-            :type family: str
-            :param size: font size as integer
-            :type size: int
+            :param font_family: font family as string
+            :type font_family: str
+            :param font_size: font size as integer
+            :type font_size: int
             """
-        settings.setValue(settings.Key.Editor_Font_Family,family)
-        settings.setValue(settings.Key.Editor_Font_Size,size)
-
         font = QtGui.QFont()
-        font.setFamily(family)
+        font.setFamily(font_family)
         font.setFixedPitch(True)
-        font.setPointSize(size)
+        font.setPointSize(font_size)
         self.setFont(font)
         self.setMarginsFont(font)
         font_metrics = QtGui.QFontMetrics(font)

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -15,19 +15,21 @@ class Editor(QsciScintilla):
 
         super().__init__(parent)
 
-        self.updateStyle(parent.editor_font_family, parent.editor_font_size)
+        self.parent = parent
 
-    def updateStyle(self, font_family, font_size):
-        """Updates the editor style. 
+        self.updateFont()
+
+    def updateFont(self):
+        """Updates the editor font. 
             :param font_family: font family as string
             :type font_family: str
             :param font_size: font size as integer
             :type font_size: int
             """
         font = QtGui.QFont()
-        font.setFamily(font_family)
+        font.setFamily(self.parent.editor_font_family)
         font.setFixedPitch(True)
-        font.setPointSize(font_size)
+        font.setPointSize(self.parent.editor_font_size)
         self.setFont(font)
         self.setMarginsFont(font)
         font_metrics = QtGui.QFontMetrics(font)

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -19,7 +19,7 @@ class Editor(QsciScintilla):
         self.updateStyle(parent.editor_font_family,parent.editor_font_size)
 
     def updateStyle(self,font_family,font_size):
-        """Updates the editor style. Caches currently selected font family and font size to the global settings.
+        """Updates the editor style. 
             :param font_family: font family as string
             :type font_family: str
             :param font_size: font size as integer

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -3,6 +3,7 @@ Class for JSON text editor
 """
 from PyQt6 import QtGui
 from PyQt6.Qsci import QsciScintilla, QsciLexerJSON
+from sscanss.config import settings
 
 
 class Editor(QsciScintilla):
@@ -15,10 +16,25 @@ class Editor(QsciScintilla):
 
         super().__init__(parent)
 
+        font_family = settings.value(settings.Key.Editor_Font_Family)
+        font_size = settings.value(settings.Key.Editor_Font_Size)
+
+        self.updateStyle(font_family,font_size)
+
+    def updateStyle(self,family,size):
+        """Updates the editor style. Caches currently selected font family and font size to the global settings.
+            :param family: font family as string
+            :type family: str
+            :param size: font size as integer
+            :type size: int
+            """
+        settings.setValue(settings.Key.Editor_Font_Family,family)
+        settings.setValue(settings.Key.Editor_Font_Size,size)
+
         font = QtGui.QFont()
-        font.setFamily('Courier')
+        font.setFamily(family)
         font.setFixedPitch(True)
-        font.setPointSize(10)
+        font.setPointSize(size)
         self.setFont(font)
         self.setMarginsFont(font)
         font_metrics = QtGui.QFontMetrics(font)

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -3,7 +3,6 @@ Class for JSON text editor
 """
 from PyQt6 import QtGui
 from PyQt6.Qsci import QsciScintilla, QsciLexerJSON
-from sscanss.config import settings
 
 
 class Editor(QsciScintilla):

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -8,7 +8,7 @@ from sscanss.core.instrument import Sequence
 from sscanss.core.scene import OpenGLRenderer, SceneManager
 from sscanss.core.util import Directions, Attributes, MessageReplyType, FileDialog, create_scroll_area, MessageType
 from sscanss.editor.designer import Designer
-from sscanss.editor.dialogs import CalibrationWidget, Controls, FindWidget
+from sscanss.editor.dialogs import CalibrationWidget, Controls, FindWidget, UpdateFontWidget
 from sscanss.editor.editor import Editor
 from sscanss.editor.presenter import EditorPresenter, MAIN_WINDOW_TITLE
 from sscanss.__version import __editor_version__, __version__
@@ -187,7 +187,10 @@ class EditorWindow(QtWidgets.QMainWindow):
         self.recent_menu = file_menu.addMenu('Open &Recent')
         file_menu.addAction(self.save_action)
         file_menu.addAction(self.save_as_action)
+        self.preferences_menu = file_menu.addMenu('Preferences')
+
         file_menu.addAction(self.exit_action)
+        file_menu.aboutToShow.connect(self.populatePreferencesMenu)
         file_menu.aboutToShow.connect(self.populateRecentMenu)
 
         edit_menu = menu_bar.addMenu('&Edit')
@@ -263,6 +266,11 @@ class EditorWindow(QtWidgets.QMainWindow):
             self.tabs.addTab(create_scroll_area(self.designer), '&Designer')
         self.tabs.setCurrentIndex(1)
 
+    def showFontComboBox(self):
+        """Opens the fonts dialog box."""
+        self.fonts_dialog = UpdateFontWidget(self)
+        self.fonts_dialog.show()
+
     def updateErrors(self, errors):
         """Updates the issue table with parser errors
 
@@ -325,6 +333,13 @@ class EditorWindow(QtWidgets.QMainWindow):
         else:
             recent_project_action = QtGui.QAction('None', self)
             self.recent_menu.addAction(recent_project_action)
+
+    def populatePreferencesMenu(self):
+        """Populates the preferences sub-menu"""
+        self.preferences_menu.clear()
+        update_font_action = QtGui.QAction('Fonts', self)
+        update_font_action.triggered.connect(self.showFontComboBox)
+        self.preferences_menu.addAction(update_font_action)
 
     def closeEvent(self, event):
         if self.presenter.askToSaveFile():

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -266,22 +266,23 @@ class EditorWindow(QtWidgets.QMainWindow):
             self.tabs.addTab(create_scroll_area(self.designer), '&Designer')
         self.tabs.setCurrentIndex(1)
 
-    def rerenderEditor(self,font_family,font_size):
+    def rerenderEditor(self, font_family, font_size):
         """Rerenders the editor, updating its style and caches currently selected style settings (font family and font size) to the application settings.
             :param font_family: font family as string
             :type font_family: str
             :param font_size: font size as integer
             :type font_size: int
             """
-        settings.setValue(settings.Key.Editor_Font_Family,font_family)
+        settings.setValue(settings.Key.Editor_Font_Family, font_family)
         settings.setValue(settings.Key.Editor_Font_Size, font_size)
-        self.editor.updateStyle(font_family,font_size)
+        self.editor.updateStyle(font_family, font_size)
 
     def showFontComboBox(self):
         """Opens the fonts dialog box."""
         self.fonts_dialog = FontWidget(self)
         self.fonts_dialog.show()
-        self.fonts_dialog.accepted.connect(lambda: self.rerenderEditor(self.fonts_dialog.preview.font().family(),self.fonts_dialog.preview.font().pointSize()))
+        self.fonts_dialog.accepted.connect(lambda: self.rerenderEditor(self.fonts_dialog.preview.font().family(),
+                                                                       self.fonts_dialog.preview.font().pointSize()))
 
     def updateErrors(self, errors):
         """Updates the issue table with parser errors

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -190,8 +190,9 @@ class EditorWindow(QtWidgets.QMainWindow):
         self.preferences_menu = file_menu.addMenu('Preferences')
 
         file_menu.addAction(self.exit_action)
-        file_menu.aboutToShow.connect(self.populatePreferencesMenu)
-        file_menu.aboutToShow.connect(self.populateRecentMenu)
+        update_font_action = QtGui.QAction('Fonts', self)
+        update_font_action.triggered.connect(self.showFontComboBox)
+        self.preferences_menu.addAction(update_font_action)
 
         edit_menu = menu_bar.addMenu('&Edit')
         edit_menu.addAction(self.find_action)
@@ -266,8 +267,8 @@ class EditorWindow(QtWidgets.QMainWindow):
             self.tabs.addTab(create_scroll_area(self.designer), '&Designer')
         self.tabs.setCurrentIndex(1)
 
-    def rerenderEditor(self, font_family, font_size):
-        """Rerenders the editor, updating its style and caches currently selected style settings (font family and font size) to the application settings.
+    def setEditorFont(self, font_family, font_size):
+        """Renders the editor font and caches currently selected font settings (family and size) to the application settings.
             :param font_family: font family as string
             :type font_family: str
             :param font_size: font size as integer
@@ -275,13 +276,15 @@ class EditorWindow(QtWidgets.QMainWindow):
             """
         settings.setValue(settings.Key.Editor_Font_Family, font_family)
         settings.setValue(settings.Key.Editor_Font_Size, font_size)
-        self.editor.updateStyle(font_family, font_size)
+        self.editor_font_family = font_family
+        self.editor_font_size = font_size
+        self.editor.updateFont()
 
     def showFontComboBox(self):
         """Opens the fonts dialog box."""
         self.fonts_dialog = FontWidget(self)
         self.fonts_dialog.show()
-        self.fonts_dialog.accepted.connect(lambda: self.rerenderEditor(self.fonts_dialog.preview.font().family(),
+        self.fonts_dialog.accepted.connect(lambda: self.setEditorFont(self.fonts_dialog.preview.font().family(),
                                                                        self.fonts_dialog.preview.font().pointSize()))
 
     def updateErrors(self, errors):
@@ -360,6 +363,8 @@ class EditorWindow(QtWidgets.QMainWindow):
         if self.presenter.askToSaveFile():
             if self.recent_projects:
                 settings.system.setValue(settings.Key.Recent_Editor_Projects.value, self.recent_projects)
+                settings.system.setValue(settings.Key.Editor_Font_Family.value, self.editor_font_family)
+                settings.system.setValue(settings.Key.Editor_Font_Size.value, self.editor_font_size)
             event.accept()
         else:
             event.ignore()

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -8,7 +8,7 @@ from sscanss.core.instrument import Sequence
 from sscanss.core.scene import OpenGLRenderer, SceneManager
 from sscanss.core.util import Directions, Attributes, MessageReplyType, FileDialog, create_scroll_area, MessageType
 from sscanss.editor.designer import Designer
-from sscanss.editor.dialogs import CalibrationWidget, Controls, FindWidget, UpdateFontWidget
+from sscanss.editor.dialogs import CalibrationWidget, Controls, FindWidget, FontWidget
 from sscanss.editor.editor import Editor
 from sscanss.editor.presenter import EditorPresenter, MAIN_WINDOW_TITLE
 from sscanss.__version import __editor_version__, __version__
@@ -60,6 +60,8 @@ class EditorWindow(QtWidgets.QMainWindow):
         self.scene.changeVisibility(Attributes.Beam, True)
         self.animate_instrument.connect(self.scene.animateInstrument)
 
+        self.readSettings()
+
         self.editor = Editor(self)
         self.editor.textChanged.connect(self.presenter.model.lazyInstrumentUpdate)
         self.splitter.addWidget(self.gl_widget)
@@ -71,8 +73,6 @@ class EditorWindow(QtWidgets.QMainWindow):
         self.updateTitle()
         self.setMinimumSize(1024, 800)
         self.setWindowIcon(QtGui.QIcon(path_for('editor-logo.png')))
-
-        self.readSettings()
 
         self.initActions()
         self.initMenus()
@@ -268,8 +268,9 @@ class EditorWindow(QtWidgets.QMainWindow):
 
     def showFontComboBox(self):
         """Opens the fonts dialog box."""
-        self.fonts_dialog = UpdateFontWidget(self)
+        self.fonts_dialog = FontWidget(self)
         self.fonts_dialog.show()
+        self.fonts_dialog.accepted.connect(lambda: self.editor.updateStyle(self.fonts_dialog.preview.font().family(),self.fonts_dialog.preview.font().pointSize()))
 
     def updateErrors(self, errors):
         """Updates the issue table with parser errors
@@ -320,6 +321,8 @@ class EditorWindow(QtWidgets.QMainWindow):
 
     def readSettings(self):
         """Loads the recent projects from settings"""
+        self.font_family = settings.value(settings.Key.Editor_Font_Family)
+        self.font_size = settings.value(settings.Key.Editor_Font_Size)
         self.recent_projects = settings.value(settings.Key.Recent_Editor_Projects)
 
     def populateRecentMenu(self):

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -356,8 +356,8 @@ class EditorWindow(QtWidgets.QMainWindow):
         if self.presenter.askToSaveFile():
             if self.recent_projects:
                 settings.system.setValue(settings.Key.Recent_Editor_Projects.value, self.recent_projects)
-                settings.system.setValue(settings.Key.Editor_Font_Family.value, self.editor_font_family)
-                settings.system.setValue(settings.Key.Editor_Font_Size.value, self.editor_font_size)
+            settings.system.setValue(settings.Key.Editor_Font_Family.value, self.editor_font_family)
+            settings.system.setValue(settings.Key.Editor_Font_Size.value, self.editor_font_size)
             event.accept()
         else:
             event.ignore()

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -352,13 +352,6 @@ class EditorWindow(QtWidgets.QMainWindow):
             recent_project_action = QtGui.QAction('None', self)
             self.recent_menu.addAction(recent_project_action)
 
-    def populatePreferencesMenu(self):
-        """Populates the preferences sub-menu"""
-        self.preferences_menu.clear()
-        update_font_action = QtGui.QAction('Fonts', self)
-        update_font_action.triggered.connect(self.showFontComboBox)
-        self.preferences_menu.addAction(update_font_action)
-
     def closeEvent(self, event):
         if self.presenter.askToSaveFile():
             if self.recent_projects:

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -267,7 +267,7 @@ class EditorWindow(QtWidgets.QMainWindow):
         self.tabs.setCurrentIndex(1)
 
     def rerenderEditor(self,font_family,font_size):
-        """Rerenders the editor, updating its style and caches currently selected style settings (font family and font size) to the global settings.
+        """Rerenders the editor, updating its style and caches currently selected style settings (font family and font size) to the application settings.
             :param font_family: font family as string
             :type font_family: str
             :param font_size: font size as integer

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -285,7 +285,7 @@ class EditorWindow(QtWidgets.QMainWindow):
         self.fonts_dialog = FontWidget(self)
         self.fonts_dialog.show()
         self.fonts_dialog.accepted.connect(lambda: self.setEditorFont(self.fonts_dialog.preview.font().family(),
-                                                                       self.fonts_dialog.preview.font().pointSize()))
+                                                                      self.fonts_dialog.preview.font().pointSize()))
 
     def updateErrors(self, errors):
         """Updates the issue table with parser errors

--- a/sscanss/editor/view.py
+++ b/sscanss/editor/view.py
@@ -266,11 +266,22 @@ class EditorWindow(QtWidgets.QMainWindow):
             self.tabs.addTab(create_scroll_area(self.designer), '&Designer')
         self.tabs.setCurrentIndex(1)
 
+    def rerenderEditor(self,font_family,font_size):
+        """Rerenders the editor, updating its style and caches currently selected style settings (font family and font size) to the global settings.
+            :param font_family: font family as string
+            :type font_family: str
+            :param font_size: font size as integer
+            :type font_size: int
+            """
+        settings.setValue(settings.Key.Editor_Font_Family,font_family)
+        settings.setValue(settings.Key.Editor_Font_Size, font_size)
+        self.editor.updateStyle(font_family,font_size)
+
     def showFontComboBox(self):
         """Opens the fonts dialog box."""
         self.fonts_dialog = FontWidget(self)
         self.fonts_dialog.show()
-        self.fonts_dialog.accepted.connect(lambda: self.editor.updateStyle(self.fonts_dialog.preview.font().family(),self.fonts_dialog.preview.font().pointSize()))
+        self.fonts_dialog.accepted.connect(lambda: self.rerenderEditor(self.fonts_dialog.preview.font().family(),self.fonts_dialog.preview.font().pointSize()))
 
     def updateErrors(self, errors):
         """Updates the issue table with parser errors
@@ -321,8 +332,8 @@ class EditorWindow(QtWidgets.QMainWindow):
 
     def readSettings(self):
         """Loads the recent projects from settings"""
-        self.font_family = settings.value(settings.Key.Editor_Font_Family)
-        self.font_size = settings.value(settings.Key.Editor_Font_Size)
+        self.editor_font_family = settings.value(settings.Key.Editor_Font_Family)
+        self.editor_font_size = settings.value(settings.Key.Editor_Font_Size)
         self.recent_projects = settings.value(settings.Key.Recent_Editor_Projects)
 
     def populateRecentMenu(self):

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -59,18 +59,18 @@ class TestEditor(unittest.TestCase):
         widget = FontWidget(window)
 
         # Test preview text configured from default settings
-        self.assertEqual(widget.preview.font().family(),'Courier')
-        self.assertEqual(widget.preview.font().pointSize(),10)
+        self.assertEqual(widget.preview.font().family(), 'Courier')
+        self.assertEqual(widget.preview.font().pointSize(), 10)
 
         # Test preview text font family changes with user selection
         self.widget.findChildren(QFontComboBox)[0].setCurrentFont(QFont("Rockwell Extra Bold"))
-        self.assertEqual(widget.preview.font().family(),"Rockwell Extra Bold")
-        self.assertEqual(widget.preview.font().pointSize(),10)
+        self.assertEqual(widget.preview.font().family(), "Rockwell Extra Bold")
+        self.assertEqual(widget.preview.font().pointSize(), 10)
 
         # Test preview text font size changes with user selection (while maintaining selected family)
         self.widget.findChildren(QComboBox)[0].setCurrentText("20")
-        self.assertEqual(widget.preview.font().family(),"Rockwell Extra Bold")
-        self.assertEqual(widget.preview.font().pointSize(),20)
+        self.assertEqual(widget.preview.font().family(), "Rockwell Extra Bold")
+        self.assertEqual(widget.preview.font().pointSize(), 20)
 
     def testUpdateEditorFont(self):
         # Create new window instance, simulate font dialog
@@ -79,21 +79,21 @@ class TestEditor(unittest.TestCase):
 
         # Test that font dialog preview text and editor font is set to default settings
         self.assertEqual(window.fonts_dialog.preview.font().toString(),'Courier,10,-1,5,400,0,0,0,0,0,0,0,0,0,0,1')
-        self.assertEqual(window.editor.font().family(),'Courier')
-        self.assertEqual(window.editor.font().pointSize(),10)
+        self.assertEqual(window.editor.font().family(), 'Courier')
+        self.assertEqual(window.editor.font().pointSize(), 10)
 
         # Simulate user font selection changing preview text, and "OK" button pushed
-        window.fonts_dialog.preview.setFont(QFont("Rockwell Extra Bold",20))
+        window.fonts_dialog.preview.setFont(QFont("Rockwell Extra Bold", 20))
         window.fonts_dialog.accept()
 
         # Test that editor font updated
-        self.assertEqual(window.editor.font().family(),'Rockwell Extra Bold')
-        self.assertEqual(window.editor.font().pointSize(),20)
+        self.assertEqual(window.editor.font().family(), 'Rockwell Extra Bold')
+        self.assertEqual(window.editor.font().pointSize(), 20)
 
         # Test that new editor font cached in settings
         window.readSettings()
-        self.assertEqual(window.editor_font_family,'Rockwell Extra Bold')
-        self.assertEqual(window.editor_font_size,20)
+        self.assertEqual(window.editor_font_family, 'Rockwell Extra Bold')
+        self.assertEqual(window.editor_font_size, 20)
 
     def testFindInText(self):
         # Testing search works, and only finds one occurrence

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -58,7 +58,7 @@ class TestEditor(unittest.TestCase):
         widget = FontWidget(self.view)
 
         # Test preview text configured from default settings
-        self.assertEqual(widget.preview.styleSheet(),"font: 10pt Courier")
+        self.assertEqual(widget.preview.styleSheet(), "font: 10pt Courier")
 
         selected_family = 'Arial'
         if platform.system() == 'Linux':
@@ -66,11 +66,11 @@ class TestEditor(unittest.TestCase):
 
         # Test preview text font family changes with user selection
         widget.family_combobox.setCurrentFont(QFont(selected_family, 9))
-        self.assertEqual(widget.preview.styleSheet(),f"font: 10pt {selected_family}")
+        self.assertEqual(widget.preview.styleSheet(), f"font: 10pt {selected_family}")
 
         # Test preview text font size changes with user selection (while maintaining selected family)
         widget.size_combobox.setCurrentText("20")
-        self.assertEqual(widget.preview.styleSheet(),f"font: 20pt {selected_family}")
+        self.assertEqual(widget.preview.styleSheet(), f"font: 20pt {selected_family}")
 
     def testUpdateEditorFont(self):
         # Create new window instance, simulate font dialog

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -58,22 +58,19 @@ class TestEditor(unittest.TestCase):
         widget = FontWidget(self.view)
 
         # Test preview text configured from default settings
-        self.assertEqual(widget.preview.font().family(), 'Courier')
-        self.assertEqual(widget.preview.font().pointSize(), 10)
+        self.assertEqual(widget.preview.styleSheet(),"font: 10pt Courier")
 
-        selected_font = 'Arial'
+        selected_family = 'Arial'
         if platform.system() == 'Linux':
-            selected_font = 'DejaVu Sans'
+            selected_family = 'Gadget'
 
         # Test preview text font family changes with user selection
-        widget.family_combobox.setCurrentFont(QFont(selected_font, 9))
-        self.assertEqual(widget.preview.font().family(), selected_font)
-        self.assertEqual(widget.preview.font().pointSize(), 10)
+        widget.family_combobox.setCurrentFont(QFont(selected_family, 9))
+        self.assertEqual(widget.preview.styleSheet(),f"font: 10pt {selected_family}")
 
         # Test preview text font size changes with user selection (while maintaining selected family)
         widget.size_combobox.setCurrentText("20")
-        self.assertEqual(widget.preview.font().family(), selected_font)
-        self.assertEqual(widget.preview.font().pointSize(), 20)
+        self.assertEqual(widget.preview.styleSheet(),f"font: 20pt {selected_family}")
 
     def testUpdateEditorFont(self):
         # Create new window instance, simulate font dialog
@@ -81,16 +78,16 @@ class TestEditor(unittest.TestCase):
         window.showFontComboBox()
 
         # Test that font dialog preview text and editor font is set to default settings
-        self.assertEqual(window.fonts_dialog.preview.font().toString(), 'Courier,10,-1,5,400,0,0,0,0,0,0,0,0,0,0,1')
+        self.assertEqual(window.fonts_dialog.preview.styleSheet(), "font: 10pt Courier")
         self.assertEqual(window.editor.font().family(), 'Courier')
         self.assertEqual(window.editor.font().pointSize(), 10)
 
         selected_font = 'Arial'
         if platform.system() == 'Linux':
-            selected_font = 'DejaVu Sans'
+            selected_font = 'Gadget'
 
         # Simulate user font selection changing preview text, and "OK" button pushed
-        window.fonts_dialog.preview.setFont(QFont(selected_font, 20))
+        window.fonts_dialog.preview.setStyleSheet(f"font: 20pt {selected_font}")
         window.fonts_dialog.accept()
 
         # Test that editor font updated

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -90,6 +90,11 @@ class TestEditor(unittest.TestCase):
         self.assertEqual(window.editor.font().family(),'Rockwell Extra Bold')
         self.assertEqual(window.editor.font().pointSize(),20)
 
+        # Test that new editor font cached in settings
+        window.readSettings()
+        self.assertEqual(window.editor_font_family,'Rockwell Extra Bold')
+        self.assertEqual(window.editor_font_size,20)
+
     def testFindInText(self):
         # Testing search works, and only finds one occurrence
         window = self.view

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,4 +1,3 @@
-import platform
 import json
 from collections import namedtuple
 import unittest

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -60,9 +60,7 @@ class TestEditor(unittest.TestCase):
         # Test preview text configured from default settings
         self.assertEqual(widget.preview.styleSheet(), "font: 10pt Courier")
 
-        selected_family = 'Arial'
-        if platform.system() == 'Linux':
-            selected_family = 'Gadget'
+        selected_family = widget.family_combobox.itemText(0)
 
         # Test preview text font family changes with user selection
         widget.family_combobox.setCurrentFont(QFont(selected_family, 9))
@@ -82,21 +80,19 @@ class TestEditor(unittest.TestCase):
         self.assertEqual(window.editor.font().family(), 'Courier')
         self.assertEqual(window.editor.font().pointSize(), 10)
 
-        selected_font = 'Arial'
-        if platform.system() == 'Linux':
-            selected_font = 'Gadget'
+        selected_family = window.fonts_dialog.family_combobox.itemText(0)
 
         # Simulate user font selection changing preview text, and "OK" button pushed
-        window.fonts_dialog.preview.setStyleSheet(f"font: 20pt {selected_font}")
+        window.fonts_dialog.preview.setStyleSheet(f"font: 20pt {selected_family}")
         window.fonts_dialog.accept()
 
         # Test that editor font updated
-        self.assertEqual(window.editor.font().family(), selected_font)
+        self.assertEqual(window.editor.font().family(), selected_family)
         self.assertEqual(window.editor.font().pointSize(), 20)
 
         # Test that new editor font cached in settings
         window.readSettings()
-        self.assertEqual(window.editor_font_family, selected_font)
+        self.assertEqual(window.editor_font_family, selected_family)
         self.assertEqual(window.editor_font_size, 20)
 
     def testFindInText(self):

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -19,7 +19,6 @@ Collimator = namedtuple("Collimator", ["name"])
 
 
 class TestEditor(unittest.TestCase):
-
     @mock.patch("sscanss.editor.view.SceneManager", autospec=True)
     def setUp(self, scene_mock):
         self.view = EditorWindow()
@@ -78,7 +77,7 @@ class TestEditor(unittest.TestCase):
         window.showFontComboBox()
 
         # Test that font dialog preview text and editor font is set to default settings
-        self.assertEqual(window.fonts_dialog.preview.font().toString(),'Courier,10,-1,5,400,0,0,0,0,0,0,0,0,0,0,1')
+        self.assertEqual(window.fonts_dialog.preview.font().toString(), 'Courier,10,-1,5,400,0,0,0,0,0,0,0,0,0,0,1')
         self.assertEqual(window.editor.font().family(), 'Courier')
         self.assertEqual(window.editor.font().pointSize(), 10)
 

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,3 +1,4 @@
+import platform
 import json
 from collections import namedtuple
 import unittest
@@ -60,15 +61,18 @@ class TestEditor(unittest.TestCase):
         self.assertEqual(widget.preview.font().family(), 'Courier')
         self.assertEqual(widget.preview.font().pointSize(), 10)
 
+        selected_font = 'Arial'
+        if platform.sys() == 'Linux':
+            selected_font = 'Gadget'
+
         # Test preview text font family changes with user selection
-        #widget.findChildren(QFontComboBox)[0].setCurrentFont(QFont("Rockwell Extra Bold", 9))
-        widget.family_combobox.setCurrentFont(QFont('Rockwell Extra Bold', 9))
-        self.assertEqual(widget.preview.font().family(), "Rockwell Extra Bold")
+        widget.family_combobox.setCurrentFont(QFont(selected_font, 9))
+        self.assertEqual(widget.preview.font().family(), selected_font)
         self.assertEqual(widget.preview.font().pointSize(), 10)
 
         # Test preview text font size changes with user selection (while maintaining selected family)
         widget.size_combobox.setCurrentText("20")
-        self.assertEqual(widget.preview.font().family(), "Rockwell Extra Bold")
+        self.assertEqual(widget.preview.font().family(), selected_font)
         self.assertEqual(widget.preview.font().pointSize(), 20)
 
     def testUpdateEditorFont(self):

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -63,7 +63,7 @@ class TestEditor(unittest.TestCase):
 
         selected_font = 'Arial'
         if platform.system() == 'Linux':
-            selected_font = 'Gadget'
+            selected_font = 'DejaVu Sans'
 
         # Test preview text font family changes with user selection
         widget.family_combobox.setCurrentFont(QFont(selected_font, 9))
@@ -87,7 +87,7 @@ class TestEditor(unittest.TestCase):
 
         selected_font = 'Arial'
         if platform.system() == 'Linux':
-            selected_font = 'Gadget'
+            selected_font = 'DejaVu Sans'
 
         # Simulate user font selection changing preview text, and "OK" button pushed
         window.fonts_dialog.preview.setFont(QFont(selected_font, 20))

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -13,7 +13,7 @@ from sscanss.editor.designer import (Designer, VisualSubComponent, GeneralCompon
                                      CollimatorComponent, FixedHardwareComponent, PositioningStacksComponent,
                                      PositionersComponent, JointSubComponent, LinkSubComponent)
 from sscanss.editor.dialogs import CalibrationWidget, Controls, FindWidget, FontWidget
-from tests.helpers import FakeSettings, TestSignal, APP, SAMPLE_IDF
+from tests.helpers import TestSignal, APP, SAMPLE_IDF
 
 Collimator = namedtuple("Collimator", ["name"])
 

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import unittest
 import unittest.mock as mock
 import numpy as np
-from PyQt6.QtWidgets import QLineEdit, QComboBox, QFontComboBox, QDoubleSpinBox
+from PyQt6.QtWidgets import QLineEdit, QComboBox, QDoubleSpinBox
 from PyQt6.QtGui import QFont
 from sscanss.core.instrument.instrument import Instrument, PositioningStack, Detector, Script, Jaws
 from sscanss.core.instrument.robotics import Link, SerialManipulator
@@ -54,20 +54,20 @@ class TestEditor(unittest.TestCase):
 
     def testFontWidget(self):
         # Create new window instance
-        window = self.view
-        widget = FontWidget(window)
+        widget = FontWidget(self.view)
 
         # Test preview text configured from default settings
         self.assertEqual(widget.preview.font().family(), 'Courier')
         self.assertEqual(widget.preview.font().pointSize(), 10)
 
         # Test preview text font family changes with user selection
-        self.widget.findChildren(QFontComboBox)[0].setCurrentFont(QFont("Rockwell Extra Bold"))
+        #widget.findChildren(QFontComboBox)[0].setCurrentFont(QFont("Rockwell Extra Bold", 9))
+        widget.family_combobox.setCurrentFont(QFont('Rockwell Extra Bold', 9))
         self.assertEqual(widget.preview.font().family(), "Rockwell Extra Bold")
         self.assertEqual(widget.preview.font().pointSize(), 10)
 
         # Test preview text font size changes with user selection (while maintaining selected family)
-        self.widget.findChildren(QComboBox)[0].setCurrentText("20")
+        widget.size_combobox.setCurrentText("20")
         self.assertEqual(widget.preview.font().family(), "Rockwell Extra Bold")
         self.assertEqual(widget.preview.font().pointSize(), 20)
 

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -62,7 +62,7 @@ class TestEditor(unittest.TestCase):
         self.assertEqual(widget.preview.font().pointSize(), 10)
 
         selected_font = 'Arial'
-        if platform.sys() == 'Linux':
+        if platform.system() == 'Linux':
             selected_font = 'Gadget'
 
         # Test preview text font family changes with user selection
@@ -85,17 +85,21 @@ class TestEditor(unittest.TestCase):
         self.assertEqual(window.editor.font().family(), 'Courier')
         self.assertEqual(window.editor.font().pointSize(), 10)
 
+        selected_font = 'Arial'
+        if platform.system() == 'Linux':
+            selected_font = 'Gadget'
+
         # Simulate user font selection changing preview text, and "OK" button pushed
-        window.fonts_dialog.preview.setFont(QFont("Rockwell Extra Bold", 20))
+        window.fonts_dialog.preview.setFont(QFont(selected_font, 20))
         window.fonts_dialog.accept()
 
         # Test that editor font updated
-        self.assertEqual(window.editor.font().family(), 'Rockwell Extra Bold')
+        self.assertEqual(window.editor.font().family(), selected_font)
         self.assertEqual(window.editor.font().pointSize(), 20)
 
         # Test that new editor font cached in settings
         window.readSettings()
-        self.assertEqual(window.editor_font_family, 'Rockwell Extra Bold')
+        self.assertEqual(window.editor_font_family, selected_font)
         self.assertEqual(window.editor_font_size, 20)
 
     def testFindInText(self):


### PR DESCRIPTION
* **What kind of change does this PR introduce(Bug fix, feature, docs update, ...)?** 
This is a feature that allows for the SScanSS-2 editor font to be updated by the user, with the new font cached in the application settings.

* **What is the current behaviour (You can also link to an open issue here)?**
Closes #117 


* **What is the new behaviour (if this is a feature change)?**
This PR implements a change to the SScanSS-2 editor such that the font (family and size) can be updated by the user.

The changes include a preferences sub-menu with a font dialog containing:
- combo boxes for font family and font size
- a preview text that shows how the new font will look

When the font dialog "OK" button is pushed, the preview font is stored in the config settings and the editor is re-rendered with the new font.

* **Does this PR introduce a breaking change (What changes might users need to make in their application due to this PR)?**
None.
