### PR TITLE
autocompletion and auto brace matching

### DIFF
--- a/docs/editor.rst
+++ b/docs/editor.rst
@@ -45,7 +45,9 @@ JSON Editor
 ===========
 The JSON editor is a QScintilla-based text editor that supports JSON highlighting, line numbers, copy and paste etc.
 The instrument description is validated in real-time as changes are made in the editor. The developer would be prompted
-to save if an attempt is made to close the editor without saving.
+to save if an attempt is made to close the editor without saving. The editor can provide autocomplete suggestions for 
+keywords when the user is actively writing an instrument descriptor file (See :ref:`IDF <Instrument Description File (IDF)>`), 
+as well as automatically matching braces.
 
 Graphic Window
 ==============

--- a/sscanss/editor/autocomplete.py
+++ b/sscanss/editor/autocomplete.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 
 AutocompletionObject = namedtuple('AutocompletionObject', ['Key', 'Type', 'Optional', 'Description'])
 
+
 class GenericInstrumentAutocomplete(enum.Enum):
     """Enumerates the generic keywords for an instrument descriptor file"""
     NAME = AutocompletionObject('name', 'string', 'Required', 'Unique name of instrument')

--- a/sscanss/editor/autocomplete.py
+++ b/sscanss/editor/autocomplete.py
@@ -6,7 +6,6 @@ from collections import namedtuple
 
 AutocompletionObject = namedtuple('AutocompletionObject', ['Key', 'Type', 'Optional', 'Description'])
 
-
 class GenericInstrumentAutocomplete(enum.Enum):
     """Enumerates the generic keywords for an instrument descriptor file"""
     NAME = AutocompletionObject('name', 'string', 'Required', 'Unique name of instrument')

--- a/sscanss/editor/autocomplete.py
+++ b/sscanss/editor/autocomplete.py
@@ -1,0 +1,138 @@
+"""
+Contains editor autocompleter keywords and related information
+"""
+import enum
+from collections import namedtuple
+
+AutocompletionObject = namedtuple('AutocompletionObject', ['Key', 'Type', 'Optional', 'Description'])
+
+
+class GenericInstrumentAutocomplete(enum.Enum):
+    """Enumerates the generic keywords for an instrument descriptor file"""
+    NAME = AutocompletionObject('name', 'string', 'Required', 'Unique name of instrument')
+    VERSION = AutocompletionObject('version', 'string', 'Required', 'Version number of file')
+    SCRIPT_TEMPLATE = AutocompletionObject('script_template', 'string', 'Optional (generic)', 'Path of script template')
+    GAUGE_VOLUME = AutocompletionObject('gauge_volume', 'array of float', 'Required', 'Position of gauge volume')
+    INCIDENT_JAWS = AutocompletionObject('incident_jaws', 'Jaws Object', 'Required', 'Jaws of instrument')
+    DETECTORS = AutocompletionObject('detectors', 'array of Detector Objects', 'Required', 'Detectors of instrument')
+    COLLIMATORS = AutocompletionObject('collimators', 'array of Collimator Objects', 'Optional (None)',
+                                       'Collimators of instrument')
+    POSITIONING_STACKS = AutocompletionObject('positioning_stacks', 'array of Positioning Stack Objects', 'Required',
+                                              'Positioning stacks of instrument')
+    POSITIONERS = AutocompletionObject('positioners', 'array of Positioner Objects', 'Required',
+                                       'Positioners of instrument')
+    FIXED_HARDWARE = AutocompletionObject('fixed_hardware', 'array of Fixed Hardware Objects', 'Optional (None)',
+                                          'Fixed hardware on instrument')
+
+
+class PositionerInstrumentAutocomplete(enum.Enum):
+    """Enumerates the positioner keywords for an instrument descriptor file"""
+    NAME = AutocompletionObject('name', 'string', 'Required', 'Unique name of positioner')
+    BASE = AutocompletionObject(
+        'base', 'array of floats', 'Optional (zero array)',
+        'Base matrix of the positioner as a 6D array. First three value should be XYZ translation and next three should be XYZ orientation in Degrees'
+    )
+    TOOL = AutocompletionObject(
+        'tool', 'array of floats', 'Optional (zero array)',
+        'Tool matrix of the positioner as a 6D array. First three value should be XYZ translation and next three should be XYZ orientation in Degrees'
+    )
+    CUSTOM_ORDER = AutocompletionObject('custom_order', 'array of strings', 'Optional (None)',
+                                        'Order of joint if order is different from kinematics')
+    JOINTS = AutocompletionObject('joints', 'array of Joint Objects', 'Required', 'Joints of the positioner')
+    LINKS = AutocompletionObject('links', 'array of Link Objects', 'Required', 'Links of the positioner')
+
+
+class JointInstrumentAutocomplete(enum.Enum):
+    """Enumerates the joint keywords for an instrument descriptor file"""
+    NAME = AutocompletionObject('name', 'string', 'Required',
+                                'Unique name of object. The joints in a positioner must have unique names')
+    TYPE = AutocompletionObject('type', 'enum [prismatic, revolute]', 'Required',
+                                'The joint type: revolute for rotating joints and prismatic for translating joints')
+    PARENT = AutocompletionObject('parent', 'string', 'Required',
+                                  'The name of the link object to which the joint is attached')
+    CHILD = AutocompletionObject('child', 'string', 'Required',
+                                 'The name of the link object that is attached to the joint')
+    AXIS = AutocompletionObject('axis', 'array of floats', 'Required',
+                                'The axis of translation or rotation with respect to the instrument coordinate frame')
+    ORIGIN = AutocompletionObject(
+        'origin', 'array of floats', 'Required',
+        'The centre of rotation for the revolute joint or the start position of prismatic joints with respect to the instrument coordinate frame'
+    )
+    LOWER_LIMIT = AutocompletionObject('lower_limit', 'float', 'Required', 'The lower limit of the joint')
+    UPPER_LIMIT = AutocompletionObject('upper_limit', 'float', 'Required', 'The upper limit of the joint')
+    HOME_OFFSET = AutocompletionObject('home_offset', 'float', 'Optional ((upper_limit+lower_limit)/2)',
+                                       'The initial offset value of the manipulator')
+
+
+class LinkInstrumentAutocomplete(enum.Enum):
+    """Enumerates the link keywords for an instrument descriptor file"""
+    NAME = AutocompletionObject('name', 'string', 'Required',
+                                'Unique name of object. The links in a positioner must have unique names')
+    VISUAL = AutocompletionObject('visual', 'Visual Object', 'Optional (None)', 'Visual representation of lobject')
+
+
+class VisualInstrumentAutocomplete(enum.Enum):
+    """Enumerates the visual keywords for an instrument descriptor file"""
+    POSE = AutocompletionObject(
+        'pose', 'array of floats', 'Optional (zero array)',
+        'Transform to apply to the mesh as a 6D array. First three value should be XYZ translation and next three should be XYZ orientation in Degrees'
+    )
+    COLOUR = AutocompletionObject('colour', 'array of floats', 'Optional (zero array)', 'Normalized RGB colour [0-1]')
+    MESH = AutocompletionObject('mesh', 'string', 'required', 'Relative file path to mesh')
+
+
+class PositioningStackInstrumentAutocomplete(enum.Enum):
+    """Enumerates the positioning stack keywords for an instrument descriptor file"""
+    NAME = AutocompletionObject('name', 'string', 'Required', 'Unique name of object')
+    POSITIONERS = AutocompletionObject('positioners', 'array of strings', 'Required',
+                                       'Names of positioners in the stack from bottom to top')
+
+
+class DetectorInstrumentAutocomplete(enum.Enum):
+    """Enumerates the detector keywords for an instrument descriptor file"""
+    NAME = AutocompletionObject('name', 'string', 'Required', 'Unique name of object')
+    DEFAULT_COLLIMATOR = AutocompletionObject('default_collimator', 'string', 'Optional (None)',
+                                              'Name of the default collimator')
+    DIFFRACTED_BEAM = AutocompletionObject('diffracted_beam', 'array of floats', 'Required',
+                                           'Normalized vector of the diffracted beam')
+    POSITIONER = AutocompletionObject('positioner', 'string', 'Optional (None)',
+                                      'Name of the positioner the detector is attached to')
+
+
+class CollimatorInstrumentAutocomplete(enum.Enum):
+    """Enumerates the collimator keywords for an instrument descriptor file"""
+    NAME = AutocompletionObject('name', 'string', 'Required', 'Unique name of object')
+    DETECTOR = AutocompletionObject('detector', 'string', 'Required', 'Name of detector the collimator is attached to')
+    APERTURE = AutocompletionObject('aperture', 'array of floats', 'Required',
+                                    'Horizontal and vertical size of collimator aperture')
+    VISUAL = AutocompletionObject('visual', 'Visual Object', 'Required', 'Visual representation of object')
+
+
+class JawsInstrumentAutocomplete(enum.Enum):
+    """Enumerates the jaws keywords for an instrument descriptor file"""
+    APERTURE = AutocompletionObject('aperture', 'array of floats', 'Required',
+                                    'Horizontal and vertical size of jaws aperture')
+    APERTURE_LOWER_LIMIT = AutocompletionObject('aperture_lower_limit', 'array of floats', 'Required',
+                                                'Horizontal and vertical lower limit of jaws')
+    APERTURE_UPPER_LIMIT = AutocompletionObject('aperture_upper_limit', 'array of floats', 'Required',
+                                                'Horizontal and vertical upper limit of jaws')
+    BEAM_DIRECTION = AutocompletionObject('beam_direction', 'array of floats', 'Required',
+                                          'Normalized vector indicating the direction of beam from source')
+    BEAM_SOURCE = AutocompletionObject('beam_source', 'array of floats', 'Required', 'Source position of the beam')
+    POSITIONER = AutocompletionObject('positioner', 'string', 'Optional (None)',
+                                      'Name of positioner the jaws are attached to')
+    VISUAL = AutocompletionObject('visual', 'Visual Object', 'Required', 'Visual representation of object')
+
+
+class FixedHardwareInstrumentAutocomplete(enum.Enum):
+    """Enumerates the fixed hardware keywords for an instrument descriptor file"""
+    NAME = AutocompletionObject('name', 'string', 'Required', 'Unique name of object')
+    VISUAL = AutocompletionObject('visual', 'Visual Object', 'Required', 'Visual representation of object')
+
+
+instrument_autocompletions = [
+    GenericInstrumentAutocomplete, PositionerInstrumentAutocomplete, JointInstrumentAutocomplete,
+    LinkInstrumentAutocomplete, VisualInstrumentAutocomplete, PositioningStackInstrumentAutocomplete,
+    DetectorInstrumentAutocomplete, CollimatorInstrumentAutocomplete, JawsInstrumentAutocomplete,
+    FixedHardwareInstrumentAutocomplete
+]

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -3,7 +3,7 @@ Class for JSON text editor
 """
 from PyQt6 import QtGui
 from PyQt6.Qsci import QsciScintilla, QsciLexerJSON, QsciAPIs
-from sscanss.editor.autocomplete import instrument_autocompletions
+from sscanss.editor.autocomplete import instrument_autocompletions, AUTOCOMPLETE_TYPE
 
 brace_match_chars = {"{": "}", "[": "]", "(": ")", "'": "'", '"': '"'}
 
@@ -30,8 +30,7 @@ class Editor(QsciScintilla):
         self.api = QsciAPIs(self.lexer)
         for keywords in instrument_autocompletions:
             for keyword in keywords:
-                descriptor = f'TYPE={keyword.value.Type}, OPTIONAL={keyword.value.Optional}, DESCRIPTION={keyword.value.Description}'
-                self.api.add(f"{keyword.value.Key} - {descriptor}")
+                self.api.add(f"{keyword.value.Key}")
         self.api.prepare()
 
         self.setAutoCompletionThreshold(1)
@@ -73,4 +72,6 @@ class Editor(QsciScintilla):
                 new_text = brace_match_chars[event.text()]
             self.insert(new_text)
             self.cursor().setPos(init_pos)
+        if event.text() == ':':
+            self.callTip()
         super().keyPressEvent(event)

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -3,7 +3,7 @@ Class for JSON text editor
 """
 from PyQt6 import QtGui
 from PyQt6.Qsci import QsciScintilla, QsciLexerJSON, QsciAPIs
-from sscanss.editor.autocomplete import instrument_autocompletions, AUTOCOMPLETE_TYPE
+from sscanss.editor.autocomplete import instrument_autocompletions
 
 brace_match_chars = {"{": "}", "[": "]", "(": ")", "'": "'", '"': '"'}
 

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -28,8 +28,8 @@ class Editor(QsciScintilla):
         self.lexer = QsciLexerJSON()
 
         self.api = QsciAPIs(self.lexer)
-        for enum in instrument_autocompletions:
-            for keyword in enum:
+        for keywords in instrument_autocompletions:
+            for keyword in keywords:
                 descriptor = f'TYPE={keyword.value.Type}, OPTIONAL={keyword.value.Optional}, DESCRIPTION={keyword.value.Description}'
                 self.api.add(f"{keyword.value.Key} - {descriptor}")
         self.api.prepare()

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -72,6 +72,4 @@ class Editor(QsciScintilla):
                 new_text = brace_match_chars[event.text()]
             self.insert(new_text)
             self.cursor().setPos(init_pos)
-        if event.text() == ':':
-            self.callTip()
         super().keyPressEvent(event)

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -30,7 +30,7 @@ class Editor(QsciScintilla):
         self.api = QsciAPIs(self.lexer)
         for keywords in instrument_autocompletions:
             for keyword in keywords:
-                self.api.add(f"{keyword.value.Key}")
+                self.api.add(keyword.value.Key)
         self.api.prepare()
 
         self.setAutoCompletionThreshold(1)

--- a/sscanss/editor/editor.py
+++ b/sscanss/editor/editor.py
@@ -2,7 +2,10 @@
 Class for JSON text editor
 """
 from PyQt6 import QtGui
-from PyQt6.Qsci import QsciScintilla, QsciLexerJSON
+from PyQt6.Qsci import QsciScintilla, QsciLexerJSON, QsciAPIs
+from sscanss.editor.autocomplete import instrument_autocompletions
+
+brace_match_chars = {"{": "}", "[": "]", "(": ")", "'": "'", '"': '"'}
 
 
 class Editor(QsciScintilla):
@@ -23,6 +26,18 @@ class Editor(QsciScintilla):
         self.setCaretLineBackgroundColor(QtGui.QColor("#ffe4e4"))
 
         self.lexer = QsciLexerJSON()
+
+        self.api = QsciAPIs(self.lexer)
+        for enum in instrument_autocompletions:
+            for keyword in enum:
+                descriptor = f'TYPE={keyword.value.Type}, OPTIONAL={keyword.value.Optional}, DESCRIPTION={keyword.value.Description}'
+                self.api.add(f"{keyword.value.Key} - {descriptor}")
+        self.api.prepare()
+
+        self.setAutoCompletionThreshold(1)
+        self.setAutoCompletionCaseSensitivity(False)
+        self.setAutoCompletionSource(self.AutoCompletionSource.AcsAPIs)
+
         self.setLexer(self.lexer)
         self.SendScintilla(QsciScintilla.SCI_STYLESETFONT, 1, b'Courier')
 
@@ -46,3 +61,16 @@ class Editor(QsciScintilla):
         self.lexer.setFont(font)
         self.setMarginsFont(font)
         self.setMarginWidth(0, QtGui.QFontMetrics(font).horizontalAdvance("00000") + 6)
+
+    def keyPressEvent(self, event):
+        """On key press, perform autobrace matching"""
+        if event.text() in brace_match_chars.keys():
+            init_pos = self.cursor().pos()
+            if self.selectedText():
+                new_text = self.selectedText() + brace_match_chars[event.text()]
+                self.removeSelectedText()
+            else:
+                new_text = brace_match_chars[event.text()]
+            self.insert(new_text)
+            self.cursor().setPos(init_pos)
+        super().keyPressEvent(event)

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -5,9 +5,11 @@ import unittest.mock as mock
 import numpy as np
 from PyQt6.QtWidgets import QLineEdit, QComboBox, QDoubleSpinBox, QFontComboBox
 from PyQt6.QtGui import QFont
+from PyQt6.QtTest import QTest
 from sscanss.core.instrument.instrument import Instrument, PositioningStack, Detector, Script, Jaws
 from sscanss.core.instrument.robotics import Link, SerialManipulator
 from sscanss.editor.main import EditorWindow
+from sscanss.editor.editor import brace_match_chars
 from sscanss.editor.widgets import PositionerWidget, JawsWidget, ScriptWidget, DetectorWidget
 from sscanss.editor.designer import (Designer, VisualSubComponent, GeneralComponent, JawComponent, DetectorComponent,
                                      CollimatorComponent, FixedHardwareComponent, PositioningStacksComponent,
@@ -1493,3 +1495,15 @@ class TestEditor(unittest.TestCase):
         component.updateValue(json_data.get('instrument').get('positioners')[0].get('links')[1], '')
         # 1) The fields in the component should be updated to match the expected result
         self.assertEqual(component.link_name.text(), 'omega_stage')
+
+    def testAutoBraceMatch(self):
+        test_editor = self.view.editor
+        for item in brace_match_chars.items():
+            opening_brace, closing_brace = item
+            QTest.keyClicks(test_editor, f'{opening_brace}')
+            self.assertEqual(test_editor.text(), f'{opening_brace}{closing_brace}')
+            test_editor.setText('stringy')
+            test_editor.selectAll(True)
+            QTest.keyClicks(test_editor, f'{opening_brace}')
+            self.assertEqual(test_editor.text(), f'{opening_brace}stringy{closing_brace}')
+            test_editor.clear()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce(Bug fix, feature, docs update, ...)?** 
Feature (Closes #83): introduces the following functionality to the sscanss-2 editor:
- autocompletion suggestions for keywords when composing the instrument descriptor file (IDF)
- automatic brace matching for brace characters ({ }, [ ], ( ), " ", ' ')

* **What is the current behaviour (You can also link to an open issue here)?**
Absence of autocompletion and autobrace matching in the editor


* **What is the new behaviour (if this is a feature change)?**
When typing, the editor can provide a list of suggested IDF keywords as found in the documentation, with metadata for
data type, optional/required, and a description of the keyword's meaning.
The editor also allows for brace characters to match automatically when types, including wrapping any highlighted text.


* **Does this PR introduce a breaking change (What changes might users need to make in their application due to this PR)?**
No


* **Other information:**
