### PR TITLE
Fixed point selection by row

### DIFF
--- a/sscanss/app/dialogs/insert.py
+++ b/sscanss/app/dialogs/insert.py
@@ -382,7 +382,6 @@ class PickPointDialog(QtWidgets.QWidget):
         self.sample_scale = 20  # This is necessary to allow sub-pixel values on the grid sizes
         self.path_pen = QtGui.QPen(QtGui.QColor(255, 0, 0), 0)
         self.point_pen = QtGui.QPen(QtGui.QColor(200, 0, 0), 0)
-        self.point_count = 0
 
         self.main_layout = QtWidgets.QVBoxLayout()
         self.setLayout(self.main_layout)

--- a/sscanss/app/dialogs/insert.py
+++ b/sscanss/app/dialogs/insert.py
@@ -1205,7 +1205,6 @@ class PickPointDialog(QtWidgets.QWidget):
         self.showBounds(self.bounds_button.isChecked())
         self.clearShape()
 
-
     def highlightPoints(self, rows):
         """Highlights the points corresponding to the rows currently selected in the point manager
         :param rows: the currently highlighted rows

--- a/sscanss/app/dialogs/insert.py
+++ b/sscanss/app/dialogs/insert.py
@@ -518,6 +518,7 @@ class PickPointDialog(QtWidgets.QWidget):
         self.createSelectionToolsTab()
         self.createGridOptionsTab()
         point_manager = PointManager(PointType.Measurement, self.parent)
+        point_manager.rows_highlighted.connect(self.highlightPoints)
         self.tabs.addTab(create_scroll_area(point_manager), 'Point Manager')
 
     def createPlaneTab(self):
@@ -1203,6 +1204,24 @@ class PickPointDialog(QtWidgets.QWidget):
         self.updateDimensionStatus()
         self.showBounds(self.bounds_button.isChecked())
         self.clearShape()
+
+
+    def highlightPoints(self, rows):
+        """Highlights the points corresponding to the rows currently selected in the point manager
+        :param rows: the currently highlighted rows
+        :type rows: List[bool]
+        """
+        items = self.scene.items()
+        fixed_points = [item for item in items if isinstance(item, GraphicsPointItem) and item.fixed]
+
+        for point, row in zip(fixed_points, reversed(rows)):
+            if row:
+                point.default_pen = self.scene.path_pen
+                point.row_highlighted = True
+            else:
+                point.default_pen = self.point_pen
+                point.row_highlighted = False
+        self.scene.update()
 
     def addPoints(self):
         """Adds the points in the scene into the measurement points of the  project"""

--- a/sscanss/app/dialogs/insert.py
+++ b/sscanss/app/dialogs/insert.py
@@ -1214,7 +1214,7 @@ class PickPointDialog(QtWidgets.QWidget):
         :type rows: List[bool]
         """
         items = self.scene.items()
-        fixed_points = {item.rank:item for item in items if isinstance(item, GraphicsPointItem) and item.fixed}
+        fixed_points = {item.rank: item for item in items if isinstance(item, GraphicsPointItem) and item.fixed}
 
         for i, row in enumerate(rows):
             if fixed_points.get(i):

--- a/sscanss/app/dialogs/insert.py
+++ b/sscanss/app/dialogs/insert.py
@@ -1206,7 +1206,7 @@ class PickPointDialog(QtWidgets.QWidget):
         self.showBounds(self.bounds_button.isChecked())
         self.clearShape()
 
-    def highlightPoints(self, rows):
+    def highlightPoints(self, highlighted_rows):
         """Highlights the points corresponding to the rows currently selected in the point manager
         
         :param rows: the currently highlighted rows
@@ -1215,14 +1215,9 @@ class PickPointDialog(QtWidgets.QWidget):
         items = self.scene.items()
         fixed_points = {item.rank: item for item in items if isinstance(item, GraphicsPointItem) and item.fixed}
 
-        for i, row in enumerate(rows):
+        for i, is_highlighted in enumerate(highlighted_rows):
             if fixed_points.get(i):
-                if row:
-                    fixed_points[i].default_pen = self.scene.path_pen
-                    fixed_points[i].highlighted = True
-                else:
-                    fixed_points[i].default_pen = self.point_pen
-                    fixed_points[i].highlighted = False
+                fixed_points[i].highlighted = is_highlighted
         self.scene.update()
 
     def addPoints(self):

--- a/sscanss/app/dialogs/managers.py
+++ b/sscanss/app/dialogs/managers.py
@@ -19,6 +19,7 @@ class PointManager(QtWidgets.QWidget):
     :param parent: main window instance
     :type parent: MainWindow
     """
+    rows_highlighted = QtCore.pyqtSignal(list)
     dock_flag = DockFlag.Bottom
 
     def __init__(self, point_type, parent):
@@ -149,6 +150,7 @@ class PointManager(QtWidgets.QWidget):
         else:
             self.move_down_button.setEnabled(True)
             self.move_up_button.setEnabled(True)
+        self.rows_highlighted.emit(selections)
 
     def closeEvent(self, event):
         selections = [False] * self.table_model.rowCount()

--- a/sscanss/app/widgets/graphics.py
+++ b/sscanss/app/widgets/graphics.py
@@ -1003,6 +1003,7 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
     def __init__(self, scale=1, parent=None):
         super().__init__(parent)
 
+        self.parent = parent
         self.scale = scale
         self.point_size = 20 * scale
         self.path_pen = QtGui.QPen(QtCore.Qt.GlobalColor.black, 0)
@@ -1101,10 +1102,10 @@ class GraphicsPointItem(QtWidgets.QAbstractGraphicsShapeItem):
         self.default_pen = QtGui.QPen(QtGui.QColor(), 0)
         self.highlight_pen = QtGui.QPen(QtGui.QColor(), 0, QtCore.Qt.PenStyle.DashLine)
         self.setFlag(QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemSendsGeometryChanges)
-        self.row_highlighted = False
+        self.highlighted = False
 
     def isSelected(self):
-        if self.row_highlighted:
+        if self.highlighted:
             return True
         return super().isSelected()
 

--- a/sscanss/app/widgets/graphics.py
+++ b/sscanss/app/widgets/graphics.py
@@ -1101,6 +1101,12 @@ class GraphicsPointItem(QtWidgets.QAbstractGraphicsShapeItem):
         self.default_pen = QtGui.QPen(QtGui.QColor(), 0)
         self.highlight_pen = QtGui.QPen(QtGui.QColor(), 0, QtCore.Qt.PenStyle.DashLine)
         self.setFlag(QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemSendsGeometryChanges)
+        self.row_highlighted = False
+
+    def isSelected(self):
+        if self.row_highlighted:
+            return True
+        return super().isSelected()
 
     def makeControllable(self, flag):
         """Enables/Disables the ability to select and move the graphics item with the mouse

--- a/sscanss/app/widgets/graphics.py
+++ b/sscanss/app/widgets/graphics.py
@@ -1003,7 +1003,6 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
     def __init__(self, scale=1, parent=None):
         super().__init__(parent)
 
-        self.parent = parent
         self.scale = scale
         self.point_size = 20 * scale
         self.path_pen = QtGui.QPen(QtCore.Qt.GlobalColor.black, 0)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -250,7 +250,6 @@ def click_table(table, mode='row', index=0, click='left', x_offset=0, y_offset=0
     :param y_offset: the amount of offset to be added to the y position
     :type y_offset: float
     """
-
     if mode == 'row':
         select_y, select_x = index, 0
     elif mode == 'column':
@@ -266,14 +265,13 @@ def click_table(table, mode='row', index=0, click='left', x_offset=0, y_offset=0
 def clear_existing_points(presenter, points, type):
     """Clears the existing points from the project
     
-    :param presenter: the presenter in which the points are currently stored
+    :param presenter: the presenter for the project holding the points
     :type presenter:  MainWindowPresenter
     :param points: an array of points to be cleared
     :type points: numpy.recarray
     :param type: measurement or fiducial points
     :type type: Literal[PointType.Measurement]
     """
-
     existing_points_indices = [n for n in range(len(points))]
     presenter.deletePoints(existing_points_indices, type)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,6 @@ from PyQt6.QtTest import QTest
 from PyQt6.QtCore import Qt, QPointF, QPoint, QEvent, QCoreApplication, QEventLoop, QDeadlineTimer, QTimer
 from PyQt6.QtGui import QMouseEvent, QWheelEvent
 from PyQt6.QtWidgets import QMainWindow, QApplication, QMessageBox
-from sscanss.core.util import PointType
 import sscanss.config as config
 
 APP = QApplication([])
@@ -80,9 +79,6 @@ class TestView(QMainWindow):
         self.showPathLength = do_nothing
         self.showScriptExport = do_nothing
         self.primitives_menu = None
-
-
-mouse = {'left': Qt.MouseButton.LeftButton, 'right': Qt.MouseButton.RightButton}
 
 
 def click_message_box(button_text):
@@ -234,46 +230,25 @@ def wait_for(predicate, timeout=5000):
     return predicate()  # Last chance
 
 
-def click_table(table, mode='row', index=0, click='left', x_offset=0, y_offset=0):
+def click_table(table, row, column, button=Qt.MouseButton.LeftButton, x_offset=0, y_offset=0):
     """Performs either a left or right mouse click on a table's row or column
     
     :param table: the table view to be clicked on
     :type table: QWidgets.QTableView
-    :param mode: select either a row or column
-    :type mode: Literal['row', 'column']
-    :param index: the index of the row/column to be clicked
-    :type index: int
-    :param click: left or right mouse button used
-    :type click: Literal['left', 'right']
-    :param x_offset: the amount of offset to be added to the x position
-    :type x_offset: float
-    :param y_offset: the amount of offset to be added to the y position
-    :type y_offset: float
+    :param row: index of the row to click
+    :type row: int
+    :param column: index of the column to click
+    :type column: int
+    :param button: button to click
+    :type button: Qt.MouseButtons
+    :param x_offset: offset to be added to the x position in pixels
+    :type x_offset: int
+    :param y_offset: offset to be added to the y position in pixels
+    :type y_offset: int
     """
-    if mode == 'row':
-        select_y, select_x = index, 0
-    elif mode == 'column':
-        select_y, select_x = 0, index
-    else:
-        return
-    x_pos = table.columnViewportPosition(select_x) + x_offset
-    y_pos = table.rowViewportPosition(select_y) + y_offset
-    pos = QPoint(x_pos, y_pos)
-    QTest.mouseClick(table.viewport(), mouse[click], pos=pos)
-
-
-def clear_existing_points(presenter, points, type):
-    """Clears the existing points from the project
-    
-    :param presenter: the presenter for the project holding the points
-    :type presenter:  MainWindowPresenter
-    :param points: an array of points to be cleared
-    :type points: numpy.recarray
-    :param type: measurement or fiducial points
-    :type type: Literal[PointType.Measurement]
-    """
-    existing_points_indices = [n for n in range(len(points))]
-    presenter.deletePoints(existing_points_indices, type)
+    x_pos = table.columnViewportPosition(row) + x_offset
+    y_pos = table.rowViewportPosition(column) + y_offset
+    QTest.mouseClick(table.viewport(), button, pos=QPoint(x_pos, y_pos))
 
 
 class QTestCase(unittest.TestCase):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -81,7 +81,9 @@ class TestView(QMainWindow):
         self.showScriptExport = do_nothing
         self.primitives_menu = None
 
+
 mouse = {'left': Qt.MouseButton.LeftButton, 'right': Qt.MouseButton.RightButton}
+
 
 def click_message_box(button_text):
     """Simulates clicking a button on a message box
@@ -231,6 +233,7 @@ def wait_for(predicate, timeout=5000):
             break
     return predicate()  # Last chance
 
+
 def click_table(table, mode='row', index=0, click='left', x_offset=0, y_offset=0):
     """Performs either a left or right mouse click on a table's row or column
     
@@ -247,7 +250,7 @@ def click_table(table, mode='row', index=0, click='left', x_offset=0, y_offset=0
     :param y_offset: the amount of offset to be added to the y position
     :type y_offset: float
     """
-        
+
     if mode == 'row':
         select_y, select_x = index, 0
     elif mode == 'column':
@@ -258,6 +261,7 @@ def click_table(table, mode='row', index=0, click='left', x_offset=0, y_offset=0
     y_pos = table.rowViewportPosition(select_y) + y_offset
     pos = QPoint(x_pos, y_pos)
     QTest.mouseClick(table.viewport(), mouse[click], pos=pos)
+
 
 def clear_existing_points(presenter, points, type):
     """Clears the existing points from the project
@@ -272,6 +276,7 @@ def clear_existing_points(presenter, points, type):
 
     existing_points_indices = [n for n in range(len(points))]
     presenter.deletePoints(existing_points_indices, type)
+
 
 class QTestCase(unittest.TestCase):
     """Test case for QT UI tests that ensure exception that occur in slot are properly

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,6 +5,7 @@ from PyQt6.QtTest import QTest
 from PyQt6.QtCore import Qt, QPointF, QPoint, QEvent, QCoreApplication, QEventLoop, QDeadlineTimer, QTimer
 from PyQt6.QtGui import QMouseEvent, QWheelEvent
 from PyQt6.QtWidgets import QMainWindow, QApplication, QMessageBox
+from sscanss.core.util import PointType
 import sscanss.config as config
 
 APP = QApplication([])
@@ -80,6 +81,7 @@ class TestView(QMainWindow):
         self.showScriptExport = do_nothing
         self.primitives_menu = None
 
+mouse = {'left': Qt.MouseButton.LeftButton, 'right': Qt.MouseButton.RightButton}
 
 def click_message_box(button_text):
     """Simulates clicking a button on a message box
@@ -229,6 +231,47 @@ def wait_for(predicate, timeout=5000):
             break
     return predicate()  # Last chance
 
+def click_table(table, mode='row', index=0, click='left', x_offset=0, y_offset=0):
+    """Performs either a left or right mouse click on a table's row or column
+    
+    :param table: the table view to be clicked on
+    :type table: QWidgets.QTableView
+    :param mode: select either a row or column
+    :type mode: Literal['row', 'column']
+    :param index: the index of the row/column to be clicked
+    :type index: int
+    :param click: left or right mouse button used
+    :type click: Literal['left', 'right']
+    :param x_offset: the amount of offset to be added to the x position
+    :type x_offset: float
+    :param y_offset: the amount of offset to be added to the y position
+    :type y_offset: float
+    """
+        
+    if mode == 'row':
+        select_y, select_x = index, 0
+    elif mode == 'column':
+        select_y, select_x = 0, index
+    else:
+        return
+    x_pos = table.columnViewportPosition(select_x) + x_offset
+    y_pos = table.rowViewportPosition(select_y) + y_offset
+    pos = QPoint(x_pos, y_pos)
+    QTest.mouseClick(table.viewport(), mouse[click], pos=pos)
+
+def clear_existing_points(presenter, points, type):
+    """Clears the existing points from the project
+    
+    :param presenter: the presenter in which the points are currently stored
+    :type presenter:  MainWindowPresenter
+    :param points: an array of points to be cleared
+    :type points: numpy.recarray
+    :param type: measurement or fiducial points
+    :type type: Literal[PointType.Measurement]
+    """
+
+    existing_points_indices = [n for n in range(len(points))]
+    presenter.deletePoints(existing_points_indices, type)
 
 class QTestCase(unittest.TestCase):
     """Test case for QT UI tests that ensure exception that occur in slot are properly

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 import numpy as np
 from PyQt6.QtTest import QTest
-from PyQt6.QtCore import Qt, QPoint, QPointF, QTimer, QSettings
+from PyQt6.QtCore import Qt, QPoint, QTimer, QSettings
 from PyQt6.QtWidgets import QToolBar, QComboBox, QToolButton, QSlider
 from OpenGL.plugins import FormatHandler
 from sscanss.app.dialogs import (InsertPrimitiveDialog, TransformDialog, InsertPointDialog, PathLengthPlotter,
@@ -18,8 +18,8 @@ from sscanss.core.math import rigid_transform
 from sscanss.core.scene import Node
 from sscanss.app.widgets.graphics import GraphicsPointItem
 from sscanss.core.util import Primitives, PointType, DockFlag
-from tests.helpers import (QTestCase, mouse_drag, mouse_wheel_scroll, click_check_box, edit_line_edit_text,
-                           clear_existing_points, click_table, MessageBoxClicker)
+from tests.helpers import (QTestCase, mouse_drag, mouse_wheel_scroll, click_check_box, edit_line_edit_text, click_table,
+                           MessageBoxClicker)
 
 WAIT_TIME = 5000
 
@@ -312,7 +312,7 @@ class TestMainWindow(QTestCase):
 
         # Sequentially select the points from the table and check they are highlighted
         for i in range(3):
-            click_table(manager.table_view, 'row', i, x_offset=5, y_offset=10)
+            click_table(manager.table_view, 0, i, x_offset=5, y_offset=10)
             self.assertTrue(find_highlighted(dialog.scene.items())[i])
 
         # Move slider down through plane of cross section
@@ -328,7 +328,7 @@ class TestMainWindow(QTestCase):
 
         # Highlight the new point
         dialog.tabs.setCurrentIndex(3)
-        click_table(manager.table_view, 'row', 3, x_offset=5, y_offset=10)
+        click_table(manager.table_view, 0, 3, x_offset=5, y_offset=10)
         self.assertTrue(find_highlighted(dialog.scene.items())[3])
 
         # Move slider upwards through cross section, adding a further two points
@@ -350,11 +350,11 @@ class TestMainWindow(QTestCase):
         dialog.tabs.setCurrentIndex(3)
         for i in range(2):
             n = 4 + i
-            click_table(manager.table_view, 'row', n, x_offset=5, y_offset=10)
+            click_table(manager.table_view, 0, n, x_offset=5, y_offset=10)
             self.assertTrue(find_highlighted(dialog.scene.items())[n])
 
-        clear_existing_points(self.window.presenter, dialog.parent_model.project_data["measurement_points"],
-                              PointType.Measurement)
+        self.window.presenter.deletePoints(list(range(len(dialog.parent_model.measurement_points))),
+                                           PointType.Measurement)
 
     def keyinFiducials(self):
         # Add Fiducial Points
@@ -379,13 +379,16 @@ class TestMainWindow(QTestCase):
         widget = self.getDockedWidget(self.window.docks, PointManager.dock_flag)
         self.assertTrue(widget.isVisible())
         self.assertEqual(widget.point_type, PointType.Fiducial)
-        click_table(widget.table_view, 'row', 1, 'left', 5, 10)
+        x_pos = widget.table_view.columnViewportPosition(0) + 5
+        y_pos = widget.table_view.rowViewportPosition(1) + 10
+        pos = QPoint(x_pos, y_pos)
+        QTest.mouseClick(widget.table_view.viewport(), Qt.MouseButton.LeftButton, pos=pos)
         QTest.mouseClick(widget.move_up_button, Qt.MouseButton.LeftButton)
         QTest.qWait(WAIT_TIME // 20)
         QTest.mouseClick(widget.move_down_button, Qt.MouseButton.LeftButton)
         QTest.qWait(WAIT_TIME // 20)
 
-        click_table(widget.table_view, 'row', 1, 'right', 5, 10)
+        QTest.mouseDClick(widget.table_view.viewport(), Qt.MouseButton.LeftButton, pos=pos)
         QTest.keyClicks(widget.table_view.viewport().focusWidget(), "100")
         QTest.keyClick(widget.table_view.viewport().focusWidget(), Qt.Key.Key_Enter)
         QTest.qWait(WAIT_TIME // 20)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -18,8 +18,8 @@ from sscanss.core.math import rigid_transform
 from sscanss.core.scene import Node
 from sscanss.app.widgets.graphics import GraphicsPointItem
 from sscanss.core.util import Primitives, PointType, DockFlag
-from tests.helpers import (QTestCase, mouse_drag, mouse_wheel_scroll, click_check_box, edit_line_edit_text, clear_existing_points, click_table,
-                           MessageBoxClicker)
+from tests.helpers import (QTestCase, mouse_drag, mouse_wheel_scroll, click_check_box, edit_line_edit_text,
+                           clear_existing_points, click_table, MessageBoxClicker)
 
 WAIT_TIME = 5000
 
@@ -107,7 +107,7 @@ class TestMainWindow(QTestCase):
         self.assertEqual(camera.mode, camera.Projection.Perspective)
 
         self.graphicalPointSelection()
-        
+
         mouse_drag(self.window.gl_widget)
         mouse_drag(self.window.gl_widget, button=Qt.MouseButton.RightButton)
         mouse_wheel_scroll(self.window.gl_widget, delta=20)
@@ -289,7 +289,7 @@ class TestMainWindow(QTestCase):
         self.window.pick_measurement_action.trigger()
         dialog = self.getDockedWidget(self.window.docks, PickPointDialog.dock_flag)
         manager = dialog.findChild(PointManager)
-        
+
         # Add three points
         QTest.mouseClick(dialog.point_selector, Qt.MouseButton.LeftButton)
         for i in range(3):
@@ -305,7 +305,10 @@ class TestMainWindow(QTestCase):
         self.assertTrue(manager.isVisible())
         self.assertEqual(manager.point_type, PointType.Measurement)
 
-        find_highlighted = lambda items: {item.rank: item.highlighted for item in items if isinstance(item, GraphicsPointItem) and item.fixed}
+        find_highlighted = lambda items: {
+            item.rank: item.highlighted
+            for item in items if isinstance(item, GraphicsPointItem) and item.fixed
+        }
 
         # Sequentially select the points from the table and check they are highlighted
         for i in range(3):
@@ -334,7 +337,7 @@ class TestMainWindow(QTestCase):
 
         QTest.mouseClick(dialog.point_selector, Qt.MouseButton.LeftButton)
         for i in range(2):
-            n = 4+i
+            n = 4 + i
             self.assertEqual(self.model.measurement_points.size, n)
             if i <= 2:
                 QTest.mouseClick(dialog.view.viewport(), Qt.MouseButton.LeftButton)
@@ -346,12 +349,13 @@ class TestMainWindow(QTestCase):
         # Check the new points are highlighted when clicking the table
         dialog.tabs.setCurrentIndex(3)
         for i in range(2):
-            n = 4+i
+            n = 4 + i
             click_table(manager.table_view, 'row', n, x_offset=5, y_offset=10)
             self.assertTrue(find_highlighted(dialog.scene.items())[n])
 
-        clear_existing_points(self.window.presenter, dialog.parent_model.project_data["measurement_points"], PointType.Measurement)
-        
+        clear_existing_points(self.window.presenter, dialog.parent_model.project_data["measurement_points"],
+                              PointType.Measurement)
+
     def keyinFiducials(self):
         # Add Fiducial Points
         self.window.keyin_fiducial_action.trigger()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -280,7 +280,8 @@ class TestPointManager(unittest.TestCase):
         self.dialog2.delete_button.click()
         self.presenter.deletePoints.assert_called_with([1, 2], PointType.Measurement)
 
-    def testMovePoints(self):
+    @mock.patch("sscanss.app.dialogs.insert.PickPointDialog")
+    def testMovePoints(self, mock_pick_point_dialog):
         self.presenter.movePoints = mock.Mock()
         self.dialog1.move_up_button.click()
         self.presenter.movePoints.assert_not_called()
@@ -293,6 +294,9 @@ class TestPointManager(unittest.TestCase):
         self.dialog1.move_up_button.click()
         self.presenter.movePoints.assert_called_with(2, 1, PointType.Fiducial)
 
+        mock_pick_point_dialog.return_value.highlightPoints = mock.Mock()
+        self.dialog2.rows_highlighted.connect(mock_pick_point_dialog.return_value.highlightPoints)
+
         self.presenter.movePoints.reset_mock()
         self.dialog2.move_down_button.click()
         self.presenter.movePoints.assert_not_called()
@@ -300,10 +304,12 @@ class TestPointManager(unittest.TestCase):
         self.dialog2.table_view.selectRow(2)
         self.dialog2.move_down_button.click()
         self.presenter.movePoints.assert_not_called()
+        mock_pick_point_dialog.return_value.highlightPoints.assert_called_with([False, False, True])
 
         self.dialog2.table_view.selectRow(0)
         self.dialog2.move_down_button.click()
         self.presenter.movePoints.assert_called_with(0, 1, PointType.Measurement)
+        mock_pick_point_dialog.return_value.highlightPoints.assert_called_with([True, False, False])
 
         table = self.dialog2.table_view
         table.setSelectionMode(table.SelectionMode.MultiSelection)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce(Bug fix, feature, docs update, ...)?** 
Feature


* **What is the current behaviour (You can also link to an open issue here)?**
Closes #139 
Selecting one or more table rows within the point manager results in highlighting of the fixed measurement points in the 3D visualisation, while the dialog's cross-section view shows no highlight on the corresponding selected points.


* **What is the new behaviour (if this is a feature change)?**
After the change, the selection of point manager table rows results in a highlighting of the corresponding measurement points.


* **Does this PR introduce a breaking change (What changes might users need to make in their application due to this PR)?**
None

