### PR TITLE
Refactors unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
       run: |
         conda init bash
         conda activate sscanss
+        conda install -y -c conda-forge numpy==1.23.5 
         python make.py --build-all
     - name: Upload coverage files
       uses: actions/upload-artifact@v3

--- a/sscanss/core/instrument/instrument.py
+++ b/sscanss/core/instrument/instrument.py
@@ -85,7 +85,6 @@ class Instrument:
         positioner_keys = self.positioning_stacks[stack_key]
 
         for i, key in enumerate(positioner_keys):
-            key = positioner_keys[i]
             if i == 0:
                 self.positioning_stack = PositioningStack(stack_key, self.positioners[key])
             else:

--- a/sscanss/settings.py
+++ b/sscanss/settings.py
@@ -117,6 +117,8 @@ class Setting:
         self.local = {}
         self.system = QtCore.QSettings(QtCore.QSettings.Format.IniFormat, QtCore.QSettings.Scope.UserScope, 'SScanSS 2',
                                        'SScanSS 2')
+        # Workaround for crashes on macOS where theme is checked after QSetting is deleted
+        self.theme = self.default(Key.Theme).default
 
     @staticmethod
     def default(key):

--- a/sscanss/themes.py
+++ b/sscanss/themes.py
@@ -29,16 +29,16 @@ class IconEngine(QtGui.QIconEngine):
     def __init__(self, file_name):
         super().__init__()
         self.file_name = file_name
-        self.theme = cfg.settings.value(cfg.settings.Key.Theme)
+        self.theme = cfg.settings.theme
         self.path = path_for(self.file_name)
         self.icon = QtGui.QIcon(self.path)
 
     def updateIcon(self):
         """Updates the Icon"""
-        if self.theme != cfg.settings.value(cfg.settings.Key.Theme):
+        if self.theme != cfg.settings.theme:
             self.path = path_for(self.file_name)
             self.icon = QtGui.QIcon(self.path)
-            self.theme = cfg.settings.value(cfg.settings.Key.Theme)
+            self.theme = cfg.settings.theme
 
     def pixmap(self, size, mode, state):
         """Creates the pixmap
@@ -130,9 +130,11 @@ class ThemeManager(QtWidgets.QWidget):
         self.reset()
         if cfg.settings.value(cfg.settings.Key.Theme) == cfg.settings.DefaultThemes.Light.value:
             cfg.settings.system.setValue(cfg.settings.Key.Theme.value, cfg.settings.DefaultThemes.Dark.value)
+            cfg.settings.theme = cfg.settings.DefaultThemes.Dark.value
             style = self.loadStylesheet("dark_theme.css")
         else:
             cfg.settings.system.setValue(cfg.settings.Key.Theme.value, cfg.settings.DefaultThemes.Light.value)
+            cfg.settings.theme = cfg.settings.DefaultThemes.Light.value
             if sys.platform == 'darwin':
                 style = self.loadStylesheet("mac_style.css")
             else:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -46,6 +46,7 @@ class FakeSettings:
     def __init__(self):
         self.local = {}
         self.system = mock.create_autospec(QSettings)
+        self.theme = self.default(Setting.Key.Theme).default
 
     def setValue(self, key, value, _=False):
         self.local[key] = value
@@ -294,9 +295,6 @@ class QTestCase(unittest.TestCase):
         self.no_exceptions = True
 
     def setUp(self):
-        if platform.system() == 'Darwin':
-            raise unittest.SkipTest('Skip UI test on MacOS because of segfaults')
-
         self.no_exceptions = True
 
         def test_exception_hook(exc_type, exc_value, exc_traceback):
@@ -307,7 +305,7 @@ class QTestCase(unittest.TestCase):
 
     def tearDown(self):
         if not self.no_exceptions:
-            raise self.failureException("An exception occured in a PyQt slot")
+            raise self.failureException("An exception occurred in a PyQt slot")
         sys.excepthook = sys.__excepthook__
 
     @staticmethod

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -49,8 +49,7 @@ class TestMainWindow(QTestCase):
         cls.toolbar = cls.window.findChild(QToolBar)
         cls.model = cls.window.presenter.model
         cls.window.presenter.notifyError = cls.notifyError
-        if platform.system() != 'Darwin':
-            cls.window.show()
+        cls.window.show()
 
     @staticmethod
     def notifyError(message, exception):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -37,14 +37,14 @@ class TestIconEngine(unittest.TestCase):
         self.path_for_mock = create_mock(self, "sscanss.themes.path_for")
 
     def testIcon(self):
-        self.settings_mock.setValue(self.settings_mock.Key.Theme, 'light')
+        self.settings_mock.theme = 'light'
         self.path_for_mock.return_value = 'light/file.png'
 
         icon = IconEngine('file.png')
         path_orig = icon.path
         theme_orig = icon.theme
 
-        self.settings_mock.setValue(self.settings_mock.Key.Theme, 'dark')
+        self.settings_mock.theme = 'dark'
         self.path_for_mock.return_value = 'dark/file.png'
 
         icon.updateIcon()


### PR DESCRIPTION
- Fixes **illegal hardware instruction** crash on macOS by replacing numpy from pip with conda
- Workaround for crash in theme.py during UI tests