### PR TITLE
Removes compiler requirement for the Linux installer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ How to build the Installer
 
         > python make.py --build-editor
 
-3. Install the create-dmg tool by running the following command. If requried [brew](https://brew.sh) has to be installed first.
+3. Install the create-dmg tool by running the following command. If required [brew](https://brew.sh) has to be installed first.
 
         > brew install create-dmg
 

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 set -e
 
-command -v gcc >/dev/null 2>&1 || { 
-  echo >&2 "gcc is required but not installed.  Aborting."; 
-  exit 1; 
-}
-
-command -v g++ >/dev/null 2>&1 || { 
-  echo >&2 "g++ is required but not installed.  Aborting.";
-  exit 1; 
-}
-
 echo ""
 echo "Welcome to the SScanSS 2 Installer"
 echo ""
@@ -128,11 +118,11 @@ echo "Building executable (This should take a few minutes) ..."
 python_exec="./envs/sscanss/bin/python"
 CFLAGS=$(./envs/sscanss/bin/python3-config --includes)
 export CFLAGS=$CFLAGS
-$python_exec -m pip install --no-cache-dir --no-index --no-build-isolation --find-links packages -r "./sscanss/requirements.txt" &>/dev/null
+$python_exec -m pip install --no-cache-dir --no-index --no-build-isolation --find-links packages -r "./sscanss/requirements.txt" >/dev/null
 if [ "$INSTALL_EDITOR" = y ]; then
-    $python_exec "./sscanss/make.py" --build-sscanss --build-editor &>/dev/null
+    $python_exec "./sscanss/make.py" --build-sscanss --build-editor >/dev/null
 else
-    $python_exec "./sscanss/make.py" --build-sscanss  &>/dev/null
+    $python_exec "./sscanss/make.py" --build-sscanss  >/dev/null
 fi
 echo "Copying executable and other files ..."
 

--- a/installer/linux/readme.txt
+++ b/installer/linux/readme.txt
@@ -1,11 +1,5 @@
 Before Installation
--------------------------------------------
-The SScanSS 2 installer requires gcc, g++, libqt5x11extras5, which can  be accessed via the OS package
-manager for example, this can be installed on Ubuntu by typing the command below in
-a terminal.
-   
-   > sudo apt-get install gcc g++ libqt5x11extras5
-   
+-------------------
 SScanSS 2 requires OpenSSL CA certificates when checking for updates. If you want to
 use this feature, install OpenSSL if not installed (Most linux distros have OpenSSL 
 pre-installed.) 
@@ -28,7 +22,7 @@ the variable is still available. You may need to write the variable to a file e.
 
 
 Installation
--------------------------------------------
+------------
 Run the install script in a terminal as below and follow the prompts to continue 
 (Use sudo to install in non-user directory).
 
@@ -44,8 +38,9 @@ the instrument editor can be run by typing the following
 
    > sscanss2-editor   
 
+
 Uninstall SScanSS 2
--------------------------------------------
+-------------------
 To uninstall the SScanSS package, simply delete the installation folder, desktop entry and symbolic link.
 If the software is installed with "sudo" the symbolic link and desktop entry will be installed in
 "/usr/local/bin/sscanss2" and "/usr/share/applications/sscanss-2.desktop" respectively otherwise
@@ -54,3 +49,13 @@ If the instrument editor is installed, delete its symbolic link also from "usr/l
 or from "$HOME/.local/bin/sscanss2-editor" for a sudo install.
 
 
+Troubleshooting
+---------------
+* If the installer throws the following error
+
+  On Linux, objdump is required. It is typically provided by the 'binutils' package installable via your Linux
+  distribution's package manager.
+
+  The solution is to install binutils
+
+  > sudo apt install binutils

--- a/make.py
+++ b/make.py
@@ -24,7 +24,7 @@ EXCLUDED_IMPORT = [
     'PyQt6.QtQml', '--exclude-module', 'PyQt6.QtQuickWidgets', '--exclude-module', 'PyQt6.QtSql', '--exclude-module',
     'PyQt6.QtSvg', '--exclude-module', 'PyQt6.QtSerialPort', '--exclude-module', 'PyQt6.QtNetwork', '--exclude-module',
     'PyQt6.QtScript', '--exclude-module', 'PyQt6.QtXml', '--exclude-module', 'PyQt6.QtXmlPatterns', '--exclude-module',
-    'sphinx'
+    'sphinx', '--exclude-module', 'numpy.array_api'
 ]
 HIDDEN_IMPORT = ['--hidden-import', 'pkg_resources.py2_warn', '--hidden-import', 'OpenGL.platform.egl']
 IS_WINDOWS = sys.platform.startswith('win')
@@ -153,7 +153,7 @@ def build_editor():
         '--name', 'editor', '--specpath',
         str(work_path), '--workpath',
         str(work_path), '--windowed', '--noconfirm', '--distpath',
-        str(dist_path), '--clean',
+        str(dist_path), '--clean', '--log-level', 'CRITICAL',
         str(main_path)
     ]
 
@@ -164,11 +164,15 @@ def build_editor():
 
     icon = 'editor-logo.icns' if IS_MAC else 'editor-logo.ico'
     pyi_args.extend(['--icon', str(INSTALLER_PATH / 'icons' / icon)])
+
+    print('Building SScanSS editor with PyInstaller')
     pyi.run(pyi_args)
     shutil.rmtree(work_path)
 
     if IS_MAC:
         shutil.rmtree(INSTALLER_PATH / 'bundle' / 'editor')
+
+    print('SScanSS editor built with no errors!\n')
 
 
 def build_sscanss():
@@ -182,7 +186,7 @@ def build_sscanss():
         '--name', 'sscanss', '--specpath',
         str(work_path), '--workpath',
         str(work_path), '--windowed', '--noconfirm', '--distpath',
-        str(dist_path), '--clean',
+        str(dist_path), '--clean', '--log-level', 'CRITICAL',
         str(main_path)
     ]
 
@@ -194,6 +198,7 @@ def build_sscanss():
     if IS_MAC:
         pyi_args.extend(['--icon', str(INSTALLER_PATH / 'icons' / 'logo.icns')])
 
+    print('Building SScanSS app with PyInstaller')
     pyi.run(pyi_args)
 
     exec_folder = next(dist_path.iterdir())
@@ -224,6 +229,8 @@ def build_sscanss():
 
     if IS_MAC:
         shutil.rmtree(INSTALLER_PATH / 'bundle' / 'app' / 'sscanss')
+
+    print('SScanSS app built with no errors!\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Since gimpact now provides wheels, the compiler requirement can be removed from the Linux installer