### PR TITLE
Adds feature to export positioner pose from a simulation

### DIFF
--- a/sscanss/__version.py
+++ b/sscanss/__version.py
@@ -64,5 +64,5 @@ class Version:
         return f'Version({self.major}, {self.minor}, {self.patch}, {self.pre_release}, {self.build})'
 
 
-__version__ = Version(2, 2, 1)
-__editor_version__ = Version(2, 2, 0)
+__version__ = Version(2, 3, 0, 'dev')
+__editor_version__ = Version(2, 3, 0, 'dev')

--- a/sscanss/app/dialogs/misc.py
+++ b/sscanss/app/dialogs/misc.py
@@ -719,21 +719,30 @@ class SimulationDialog(QtWidgets.QWidget):
         button_layout.addWidget(divider)
         button_layout.addSpacing(5)
 
+        self.export_poses_button = create_tool_button(
+            tooltip='Export Pose Matrices',
+            style_name='ToolButton',
+            status_tip='Export pose matrices of the positioner for current simulation',
+            icon='arrow-down.png')
+        self.export_poses_button.clicked.connect(self.parent.presenter.exportPoses)
+
         self.path_length_button = create_tool_button(tooltip='Plot Path Length',
                                                      style_name='ToolButton',
                                                      status_tip='Plot calculated path length for current simulation',
                                                      icon='line-chart.png')
         self.path_length_button.clicked.connect(self.parent.showPathLength)
 
-        self.export_button = create_tool_button(tooltip='Export Script',
-                                                style_name='ToolButton',
-                                                status_tip='Export script for current simulation',
-                                                icon='export.png')
-        self.export_button.clicked.connect(self.parent.showScriptExport)
+        self.export_script_button = create_tool_button(tooltip='Export Script',
+                                                       style_name='ToolButton',
+                                                       status_tip='Export script for current simulation',
+                                                       icon='export.png')
+        self.export_script_button.clicked.connect(self.parent.showScriptExport)
 
         button_layout.addWidget(self.path_length_button)
         button_layout.addSpacing(5)
-        button_layout.addWidget(self.export_button)
+        button_layout.addWidget(self.export_poses_button)
+        button_layout.addSpacing(5)
+        button_layout.addWidget(self.export_script_button)
         main_layout.addLayout(button_layout)
 
         self.progress_label = QtWidgets.QLabel()

--- a/sscanss/app/window/presenter.py
+++ b/sscanss/app/window/presenter.py
@@ -1147,6 +1147,21 @@ class MainWindowPresenter:
                     text_file.write(script_text)
                 return True
             except OSError as e:
-                self.notifyError(f'A error occurred while attempting to save this project ({filename})', e)
+                self.notifyError(f'A error occurred while attempting to export this project script ({filename})', e)
 
         return False
+
+    def exportPoses(self):
+        """Exports simulation poses to text file."""
+        if not self.view.isValidSimulation(self.model.simulation):
+            return
+
+        save_path = f'{os.path.splitext(self.model.save_path)[0]}_poses' if self.model.save_path else ''
+        filename = self.view.showSaveDialog('Text File (*.txt)', current_dir=save_path, title='Export Poses')
+
+        if filename:
+            poses = [result.pose_matrix[:3, :].flatten('F') for result in self.model.simulation.results]
+            try:
+                np.savetxt(filename, poses, delimiter='\t', fmt='%.7f')
+            except OSError as e:
+                self.notifyError(f'A error occurred while attempting to export this simulation poses ({filename})', e)

--- a/sscanss/app/window/presenter.py
+++ b/sscanss/app/window/presenter.py
@@ -1147,7 +1147,7 @@ class MainWindowPresenter:
                     text_file.write(script_text)
                 return True
             except OSError as e:
-                self.notifyError(f'A error occurred while attempting to export this project script ({filename})', e)
+                self.notifyError(f'An error occurred while attempting to export this project script ({filename})', e)
 
         return False
 
@@ -1164,4 +1164,4 @@ class MainWindowPresenter:
             try:
                 np.savetxt(filename, poses, delimiter='\t', fmt='%.7f')
             except OSError as e:
-                self.notifyError(f'A error occurred while attempting to export this simulation poses ({filename})', e)
+                self.notifyError(f'An error occurred while attempting to export this simulation poses ({filename})', e)

--- a/sscanss/app/window/view.py
+++ b/sscanss/app/window/view.py
@@ -995,11 +995,22 @@ class MainWindow(QtWidgets.QMainWindow):
         calibration_error = CalibrationErrorDialog(self, pose_id, fiducial_id, error)
         return calibration_error.exec() == QtWidgets.QDialog.DialogCode.Accepted
 
+    def isValidSimulation(self, simulation):
+        if simulation is None:
+            self.showMessage('There are no simulation results.', MessageType.Information)
+            return False
+
+        if simulation.isRunning():
+            self.showMessage('Finish or Stop the current simulation before attempting other actions.',
+                             MessageType.Information)
+            return False
+
+        return True
+
     def showPathLength(self):
         """Opens the path length plotter dialog"""
         simulation = self.presenter.model.simulation
-        if simulation is None:
-            self.showMessage('There are no simulation results.', MessageType.Information)
+        if not self.isValidSimulation(simulation):
             return
 
         if not simulation.compute_path_length:
@@ -1017,13 +1028,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def showScriptExport(self):
         """Shows the dialog for exporting the resulting script from a simulation"""
         simulation = self.presenter.model.simulation
-        if simulation is None:
-            self.showMessage('There are no simulation results to write in script.', MessageType.Information)
-            return
-
-        if simulation.isRunning():
-            self.showMessage('Finish or Stop the current simulation before attempting to write script.',
-                             MessageType.Information)
+        if not self.isValidSimulation(simulation):
             return
 
         if not simulation.has_valid_result:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -821,7 +821,7 @@ class TestMainWindow(QTestCase):
         path_length_plotter.close()
         self.assertFalse(path_length_plotter.isVisible())
 
-        QTest.mouseClick(widget.export_button, Qt.MouseButton.LeftButton)
+        QTest.mouseClick(widget.export_script_button, Qt.MouseButton.LeftButton)
         script_exporter = self.window.findChild(ScriptExportDialog)
         self.assertTrue(script_exporter.isVisible())
         script_exporter.close()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -168,15 +168,16 @@ class TestSimulationDialog(unittest.TestCase):
         limit = IKResult([87.8], IKSolver.Status.HardwareLimit, (0.0, 0.0, 0.0), (1.0, 1.0, 0.0), True, False)
         unreachable = IKResult([87.8], IKSolver.Status.Unreachable, (0.0, 0.0, 0.0), (1.0, 1.0, 0.0), True, False)
         deformed = IKResult([87.8], IKSolver.Status.DeformedVectors, (0.0, 0.0, 0.0), (1.0, 1.0, 0.0), True, False)
+        pose_matrix = Matrix44([[1, 0, 0, 1], [1, 0, 1, 2], [0, 1, 0, -1], [0, 0, 0, 1]])
 
         self.simulation_mock.results = [
-            SimulationResult("1", converged, (["X"], [90]), 0, (120, ), [False, False]),
-            SimulationResult("2", converged, (["X"], [90]), 0, (120, ), [False, True]),
-            SimulationResult("3", not_converged, (["X"], [87.8]), 0, (25, ), [True, True]),
-            SimulationResult("4", non_fatal, (["X"], [45]), 0),
-            SimulationResult("5", limit, (["X"], [87.8]), 0, (25, ), [True, True]),
-            SimulationResult("6", unreachable, (["X"], [87.8]), 0, (25, ), [True, True]),
-            SimulationResult("7", deformed, (["X"], [87.8]), 0, (25, ), [True, True]),
+            SimulationResult("1", converged, pose_matrix, (["X"], [90]), 0, (120, ), [False, False]),
+            SimulationResult("2", converged, pose_matrix, (["X"], [90]), 0, (120, ), [False, True]),
+            SimulationResult("3", not_converged, pose_matrix, (["X"], [87.8]), 0, (25, ), [True, True]),
+            SimulationResult("4", non_fatal, pose_matrix, (["X"], [45]), 0),
+            SimulationResult("5", limit, pose_matrix, (["X"], [87.8]), 0, (25, ), [True, True]),
+            SimulationResult("6", unreachable, pose_matrix, (["X"], [87.8]), 0, (25, ), [True, True]),
+            SimulationResult("7", deformed, pose_matrix, (["X"], [87.8]), 0, (25, ), [True, True]),
             SimulationResult("8", skipped=True, note="something happened"),
         ]
         self.simulation_mock.count = len(self.simulation_mock.results)
@@ -186,6 +187,9 @@ class TestSimulationDialog(unittest.TestCase):
         self.model_mock.return_value.simulation_created.emit()
         self.simulation_mock.result_updated.emit(False)
         self.dialog.filter_button_group.button(3).toggle()
+
+        np.testing.assert_array_equal(self.simulation_mock.results[1].pose_matrix, pose_matrix)
+        np.testing.assert_array_equal(self.simulation_mock.results[7].pose_matrix, Matrix44.identity())
 
         self.assertEqual(self.dialog.result_counts[self.dialog.ResultKey.Good], 1)
         self.assertEqual(self.dialog.result_counts[self.dialog.ResultKey.Warn], 5)
@@ -1031,9 +1035,9 @@ class TestScriptExportDialog(unittest.TestCase):
         non_fatal = IKResult([45], IKSolver.Status.Failed, (-1.0, -1.0, -1.0), (-1.0, -1.0, -1.0), False, False)
         self.model_mock.return_value.instrument.script = self.template_mock
         self.simulation_mock.results = [
-            SimulationResult("1", converged, (["X"], [90]), 0, (120, ), [False, True]),
-            SimulationResult("3", non_fatal, (["X"], [45]), 0, None, None),
-            SimulationResult("2", not_converged, (["X"], [87.8]), 0, (25, ), [True, True]),
+            SimulationResult("1", converged, Matrix44.identity(), (["X"], [90]), 0, (120, ), [False, True]),
+            SimulationResult("3", non_fatal, Matrix44.identity(), (["X"], [45]), 0, None, None),
+            SimulationResult("2", not_converged, Matrix44.identity(), (["X"], [87.8]), 0, (25, ), [True, True]),
         ]
 
         self.presenter = MainWindowPresenter(self.view)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What is the new behaviour (if this is a feature change)?**
This adds the option to download positioner pose (position and orientation) matrices after a simulation. To use the feature:
1.  Run a simulation as normal. 
2. When the simulation is done, click the download button shown in the image below.
3. Select save location 
4. Each row in the file is a flatten matrix. The matrices are stored column first i.e. [m00, m10, m20, m01, m11, m21, m02, m12, m22, m03, m13, m23] so the first 9 values are for the rotation matrix and the last 3 the translation vector.   

* **Does this PR introduce a breaking change (What changes might users need to make in their application due to this PR)?**
No

* **Other information:**
![Screenshot 2025-04-29 123451](https://github.com/user-attachments/assets/11ac5721-7147-4524-9e3f-276799c48e88)
